### PR TITLE
Cleanup and deduplication in preparation for UDP support

### DIFF
--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -6,8 +6,6 @@ import _Concurrency
 #error("WendyNet: enable exactly one of the 'Standard' or 'WendyLite' traits.")
 #endif
 
-let wendyNetMaximumMessageLength = 1024
-
 // MARK: - ByteBuffer
 
 #if WendyNetBackendStandard
@@ -321,24 +319,6 @@ public struct Accepted<Message: Sendable>: Sendable {
     }
 }
 
-/// Internal step results.
-enum InboundStep<Message: Sendable>: Sendable {
-    case message(Message)
-    case end
-    case failure(WendyNetError)
-}
-
-enum OutboundStep: Sendable {
-    case accepted
-    case failure(WendyNetError)
-}
-
-enum AcceptedStep<Message: Sendable>: Sendable {
-    case channel(Channel<Message>)
-    case end
-    case failure(WendyNetError)
-}
-
 // MARK: - Channel
 
 /// A live network connection, generic on the message type produced by the pipeline.
@@ -502,109 +482,6 @@ public final class Listener<Message: Sendable>: Sendable {
     init(port: UInt16, core: ListenerCore<Message>) {
         self.port = port
         self.core = core
-    }
-}
-
-// MARK: - Pipeline Closures
-
-/// Closure bundle produced by a pipeline factory.
-struct PipelineClosures<Message> {
-    let decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
-    let encode: (Message) -> ByteBuffer
-    let started: (ConnectionContext) -> Void
-}
-
-/// Closure bundle for a framer (ByteBuffer -> ByteBuffer, stream transports only).
-struct FramerClosures {
-    let decode: (ByteBuffer, (ByteBuffer) -> Void, (WendyNetError) -> Void) -> Void
-    let encode: (ByteBuffer) -> ByteBuffer
-    let started: (ConnectionContext) -> Void
-
-    /// Wrap a pipeline's closures so the framer runs first on inbound
-    /// and last on outbound.
-    func composing<Message>(_ inner: PipelineClosures<Message>) -> PipelineClosures<Message> {
-        let framerDecode = self.decode
-        let framerEncode = self.encode
-        let framerStarted = self.started
-        return PipelineClosures<Message>(
-            decode: { buf, emit, fail in
-                framerDecode(buf, { frameBuf in
-                    inner.decode(frameBuf, emit, fail)
-                }, fail)
-            },
-            encode: { msg in
-                framerEncode(inner.encode(msg))
-            },
-            started: { context in
-                framerStarted(context)
-                inner.started(context)
-            }
-        )
-    }
-}
-
-// MARK: - Bootstrap configuration
-
-/// Shared configuration backing both `ClientBootstrap` and `ServerBootstrap`.
-struct BootstrapConfig<Message: Sendable>: Sendable {
-    var security: SecurityMode = .insecure
-    var udpAssociationTimeoutSeconds: Int = 60
-    let pipelineFactory: @Sendable () -> PipelineClosures<Message>
-    var framerFactory: (@Sendable () -> FramerClosures)? = nil
-
-    /// The identity pipeline: raw bytes through, no decode/encode transform.
-    static func passthrough() -> BootstrapConfig<ByteBuffer> {
-        BootstrapConfig<ByteBuffer>(
-            pipelineFactory: {
-                PipelineClosures(
-                    decode: { buf, emit, _ in emit(buf) },
-                    encode: { $0 },
-                    started: { _ in }
-                )
-            }
-        )
-    }
-
-    /// Re-key this config to a new message type, swapping in a fresh pipeline
-    /// factory while preserving every other field (so `.pipeline()` can't drop
-    /// a previously configured option).
-    func reframed<New: Sendable>(
-        pipelineFactory: @escaping @Sendable () -> PipelineClosures<New>
-    ) -> BootstrapConfig<New> {
-        BootstrapConfig<New>(
-            security: security,
-            udpAssociationTimeoutSeconds: udpAssociationTimeoutSeconds,
-            pipelineFactory: pipelineFactory,
-            framerFactory: framerFactory
-        )
-    }
-}
-
-/// Wrap a `PipelineStage` factory into framer closures.
-private func makeFramerClosures<F: PipelineStage & SendableMetatype>(
-    _ factory: @escaping @Sendable () -> F
-) -> @Sendable () -> FramerClosures where F.Input == ByteBuffer, F.Output == ByteBuffer {
-    {
-        let framer = factory()
-        return FramerClosures(
-            decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
-            encode: { buf in framer.encode(buf) },
-            started: { context in framer.started(context: context) }
-        )
-    }
-}
-
-/// Wrap a `PipelineStage` factory into pipeline closures.
-private func makePipelineClosures<P: PipelineStage & SendableMetatype>(
-    _ build: @escaping @Sendable () -> P
-) -> @Sendable () -> PipelineClosures<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
-    {
-        let pipeline = build()
-        return PipelineClosures(
-            decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
-            encode: { msg in pipeline.encode(msg) },
-            started: { context in pipeline.started(context: context) }
-        )
     }
 }
 

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -115,20 +115,34 @@ public struct ByteBuffer: Sendable {
 
     // MARK: Write (advances writerIndex)
 
+    /// Writes `bytes` at `writerIndex`, then advances `writerIndex` past them.
+    private mutating func writeAtCursor(_ bytes: [UInt8]) {
+        let end = writerIndex + bytes.count
+        if writerIndex == storage.count {
+            storage.append(contentsOf: bytes) // append at end (common case)
+        } else if end <= storage.count {
+            storage.replaceSubrange(writerIndex ..< end, with: bytes) // fully overwrite in range
+        } else {
+            let split = storage.count - writerIndex // overwrite the in-range part
+            storage.replaceSubrange(writerIndex ..< storage.count, with: bytes[..<split])
+            storage.append(contentsOf: bytes[split...]) // then extend with the rest
+        }
+        writerIndex = end
+    }
+
     @discardableResult
     public mutating func writeBytes(_ bytes: [UInt8]) -> Int {
-        storage.append(contentsOf: bytes)
-        writerIndex += bytes.count
+        writeAtCursor(bytes)
         return bytes.count
     }
 
-    /// Consumes readable bytes from `buffer` and appends them to `self`.
+    /// Consumes readable bytes from `buffer` and writes them at this buffer's
+    /// write cursor.
     @discardableResult
     public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
         let count = buffer.readableBytes
         guard count > 0 else { return 0 }
-        storage.append(contentsOf: buffer.storage[buffer.readerIndex ..< buffer.writerIndex])
-        writerIndex += count
+        writeAtCursor(Array(buffer.storage[buffer.readerIndex ..< buffer.writerIndex]))
         buffer.readerIndex += count
         return count
     }
@@ -136,10 +150,16 @@ public struct ByteBuffer: Sendable {
     @discardableResult
     public mutating func writeInteger<T: FixedWidthInteger>(_ value: T) -> Int {
         let size = MemoryLayout<T>.size
-        for i in (0 ..< size).reversed() {
-            storage.append(UInt8(truncatingIfNeeded: value >> (i * 8)))
+        // Big-endian, written byte-by-byte at the cursor
+        for shift in stride(from: (size - 1) * 8, through: 0, by: -8) {
+            let byte = UInt8(truncatingIfNeeded: value >> shift)
+            if writerIndex < storage.count {
+                storage[writerIndex] = byte
+            } else {
+                storage.append(byte)
+            }
+            writerIndex += 1
         }
-        writerIndex += size
         return size
     }
 

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -556,6 +556,71 @@ struct _FramerClosures {
     }
 }
 
+// MARK: - Bootstrap configuration
+
+/// Shared configuration backing both `ClientBootstrap` and `ServerBootstrap`.
+struct _BootstrapConfig<Message: Sendable>: Sendable {
+    var security: SecurityMode = .insecure
+    var udpAssociationTimeoutSeconds: Int = 60
+    let pipelineFactory: @Sendable () -> _PipelineClosures<Message>
+    var framerFactory: (@Sendable () -> _FramerClosures)? = nil
+
+    /// The identity pipeline: raw bytes through, no decode/encode transform.
+    static func passthrough() -> _BootstrapConfig<ByteBuffer> {
+        _BootstrapConfig<ByteBuffer>(
+            pipelineFactory: {
+                _PipelineClosures(
+                    decode: { buf, emit, _ in emit(buf) },
+                    encode: { $0 },
+                    started: { _ in }
+                )
+            }
+        )
+    }
+
+    /// Re-key this config to a new message type, swapping in a fresh pipeline
+    /// factory while preserving every other field (so `.pipeline()` can't drop
+    /// a previously configured option).
+    func reframed<New: Sendable>(
+        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<New>
+    ) -> _BootstrapConfig<New> {
+        _BootstrapConfig<New>(
+            security: security,
+            udpAssociationTimeoutSeconds: udpAssociationTimeoutSeconds,
+            pipelineFactory: pipelineFactory,
+            framerFactory: framerFactory
+        )
+    }
+}
+
+/// Wrap a `PipelineStage` factory into framer closures.
+private func _makeFramerClosures<F: PipelineStage & SendableMetatype>(
+    _ factory: @escaping @Sendable () -> F
+) -> @Sendable () -> _FramerClosures where F.Input == ByteBuffer, F.Output == ByteBuffer {
+    {
+        let framer = factory()
+        return _FramerClosures(
+            decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
+            encode: { buf in framer.encode(buf) },
+            started: { context in framer.started(context: context) }
+        )
+    }
+}
+
+/// Wrap a `PipelineStage` factory into pipeline closures.
+private func _makePipelineClosures<P: PipelineStage & SendableMetatype>(
+    _ build: @escaping @Sendable () -> P
+) -> @Sendable () -> _PipelineClosures<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
+    {
+        let pipeline = build()
+        return _PipelineClosures(
+            decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
+            encode: { msg in pipeline.encode(msg) },
+            started: { context in pipeline.started(context: context) }
+        )
+    }
+}
+
 // MARK: - Client Bootstrap
 
 /// Configures and creates outbound Channels.
@@ -571,47 +636,34 @@ struct _FramerClosures {
 /// `connect(to:)` lives in the active backend file.
 public struct ClientBootstrap<Message: Sendable>: Sendable {
     let wendyNet: WendyNet
-    var security: SecurityMode = .insecure
-    var udpAssociationTimeoutSeconds: Int = 60
-    let _pipelineFactory: @Sendable () -> _PipelineClosures<Message>
-    var _framerFactory: (@Sendable () -> _FramerClosures)?
+    var config: _BootstrapConfig<Message>
+
+    // Accessors used by the backend `connect(to:)` extensions.
+    var security: SecurityMode { config.security }
+    var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
+    var _pipelineFactory: @Sendable () -> _PipelineClosures<Message> { config.pipelineFactory }
+    var _framerFactory: (@Sendable () -> _FramerClosures)? { config.framerFactory }
 
     /// Create a bootstrap with no pipeline. Produces Channel<ByteBuffer>.
     public init(wendyNet: WendyNet) where Message == ByteBuffer {
         self.wendyNet = wendyNet
-        self._pipelineFactory = {
-            _PipelineClosures(
-                decode: { buf, emit, _ in emit(buf) },
-                encode: { $0 },
-                started: { _ in }
-            )
-        }
-        self._framerFactory = nil
+        self.config = .passthrough()
     }
 
-    init(
-        wendyNet: WendyNet,
-        security: SecurityMode,
-        udpTimeout: Int,
-        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<Message>,
-        framerFactory: (@Sendable () -> _FramerClosures)?
-    ) {
+    init(wendyNet: WendyNet, config: _BootstrapConfig<Message>) {
         self.wendyNet = wendyNet
-        self.security = security
-        self.udpAssociationTimeoutSeconds = udpTimeout
-        self._pipelineFactory = pipelineFactory
-        self._framerFactory = framerFactory
+        self.config = config
     }
 
     public func security(_ mode: SecurityMode) -> ClientBootstrap {
         var copy = self
-        copy.security = mode
+        copy.config.security = mode
         return copy
     }
 
     public func udpAssociationTimeout(seconds: Int) -> ClientBootstrap {
         var copy = self
-        copy.udpAssociationTimeoutSeconds = seconds
+        copy.config.udpAssociationTimeoutSeconds = seconds
         return copy
     }
 
@@ -621,14 +673,7 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
         _ factory: @escaping @Sendable () -> F
     ) -> ClientBootstrap where F.Input == ByteBuffer, F.Output == ByteBuffer {
         var copy = self
-        copy._framerFactory = {
-            let framer = factory()
-            return _FramerClosures(
-                decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
-                encode: { buf in framer.encode(buf) },
-                started: { context in framer.started(context: context) }
-            )
-        }
+        copy.config.framerFactory = _makeFramerClosures(factory)
         return copy
     }
 
@@ -637,20 +682,9 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
     public func pipeline<P: PipelineStage & SendableMetatype>(
         @PipelineBuilder _ build: @escaping @Sendable () -> P
     ) -> ClientBootstrap<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
-        let framer = _framerFactory
-        return ClientBootstrap<P.Output>(
+        ClientBootstrap<P.Output>(
             wendyNet: wendyNet,
-            security: security,
-            udpTimeout: udpAssociationTimeoutSeconds,
-            pipelineFactory: {
-                let pipeline = build()
-                return _PipelineClosures(
-                    decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
-                    encode: { msg in pipeline.encode(msg) },
-                    started: { context in pipeline.started(context: context) }
-                )
-            },
-            framerFactory: framer
+            config: config.reframed(pipelineFactory: _makePipelineClosures(build))
         )
     }
 }
@@ -662,46 +696,33 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
 /// `bind(port:)` lives in the active backend file.
 public struct ServerBootstrap<Message: Sendable>: Sendable {
     let wendyNet: WendyNet
-    var security: SecurityMode = .insecure
-    var udpAssociationTimeoutSeconds: Int = 60
-    let _pipelineFactory: @Sendable () -> _PipelineClosures<Message>
-    var _framerFactory: (@Sendable () -> _FramerClosures)?
+    var config: _BootstrapConfig<Message>
+
+    // Accessors used by the backend `bind(port:)` extensions.
+    var security: SecurityMode { config.security }
+    var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
+    var _pipelineFactory: @Sendable () -> _PipelineClosures<Message> { config.pipelineFactory }
+    var _framerFactory: (@Sendable () -> _FramerClosures)? { config.framerFactory }
 
     public init(wendyNet: WendyNet) where Message == ByteBuffer {
         self.wendyNet = wendyNet
-        self._pipelineFactory = {
-            _PipelineClosures(
-                decode: { buf, emit, _ in emit(buf) },
-                encode: { $0 },
-                started: { _ in }
-            )
-        }
-        self._framerFactory = nil
+        self.config = .passthrough()
     }
 
-    init(
-        wendyNet: WendyNet,
-        security: SecurityMode,
-        udpTimeout: Int,
-        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<Message>,
-        framerFactory: (@Sendable () -> _FramerClosures)?
-    ) {
+    init(wendyNet: WendyNet, config: _BootstrapConfig<Message>) {
         self.wendyNet = wendyNet
-        self.security = security
-        self.udpAssociationTimeoutSeconds = udpTimeout
-        self._pipelineFactory = pipelineFactory
-        self._framerFactory = framerFactory
+        self.config = config
     }
 
     public func security(_ mode: SecurityMode) -> ServerBootstrap {
         var copy = self
-        copy.security = mode
+        copy.config.security = mode
         return copy
     }
 
     public func udpAssociationTimeout(seconds: Int) -> ServerBootstrap {
         var copy = self
-        copy.udpAssociationTimeoutSeconds = seconds
+        copy.config.udpAssociationTimeoutSeconds = seconds
         return copy
     }
 
@@ -710,14 +731,7 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
         _ factory: @escaping @Sendable () -> F
     ) -> ServerBootstrap where F.Input == ByteBuffer, F.Output == ByteBuffer {
         var copy = self
-        copy._framerFactory = {
-            let framer = factory()
-            return _FramerClosures(
-                decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
-                encode: { buf in framer.encode(buf) },
-                started: { context in framer.started(context: context) }
-            )
-        }
+        copy.config.framerFactory = _makeFramerClosures(factory)
         return copy
     }
 
@@ -726,20 +740,9 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
     public func pipeline<P: PipelineStage & SendableMetatype>(
         @PipelineBuilder _ build: @escaping @Sendable () -> P
     ) -> ServerBootstrap<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
-        let framer = _framerFactory
-        return ServerBootstrap<P.Output>(
+        ServerBootstrap<P.Output>(
             wendyNet: wendyNet,
-            security: security,
-            udpTimeout: udpAssociationTimeoutSeconds,
-            pipelineFactory: {
-                let pipeline = build()
-                return _PipelineClosures(
-                    decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
-                    encode: { msg in pipeline.encode(msg) },
-                    started: { context in pipeline.started(context: context) }
-                )
-            },
-            framerFactory: framer
+            config: config.reframed(pipelineFactory: _makePipelineClosures(build))
         )
     }
 }

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -864,7 +864,7 @@ public struct DiscoveryOptions: Sendable {
 public enum SecurityMode: Sendable {
     case wendyPeer
     case insecure
-    case tls(tls: TLSOptions)
+    case tls(TLSOptions)
 }
 
 public struct TLSOptions: Sendable {

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -29,13 +29,18 @@ public typealias ByteBuffer = NIOCore.ByteBuffer
 /// Slicing returns a new ByteBuffer that shares backing storage via Swift's
 /// built-in Array CoW.
 public struct ByteBuffer: Sendable {
+    // `storage` is shared between a buffer and its slices via Array CoW (no copy
+    // until either side mutates). `base` is the absolute offset within `storage`
+    // of this buffer's logical index 0.
     private var storage: [UInt8] = []
+    private var base: Int = 0
     public private(set) var readerIndex: Int = 0
     public private(set) var writerIndex: Int = 0
 
     public var readableBytes: Int { writerIndex - readerIndex }
-    public var writableBytes: Int { capacity - writerIndex }
-    public var capacity: Int { storage.count }
+    // This implementation does currently not support preallocation.
+    public var writableBytes: Int { 0 }
+    public var capacity: Int { writerIndex }
 
     public init() {}
 
@@ -44,14 +49,14 @@ public struct ByteBuffer: Sendable {
         writerIndex = bytes.count
     }
 
-    // MARK: Slicing (shares storage, no copy)
+    // MARK: Slicing (shares storage via CoW; indices rebased to 0, matching NIO)
 
     public func getSlice(at index: Int, length: Int) -> ByteBuffer? {
-        guard index >= readerIndex, index + length <= writerIndex else { return nil }
-        var slice = ByteBuffer()
-        slice.storage = storage
-        slice.readerIndex = index
-        slice.writerIndex = index + length
+        guard index >= 0, length >= 0, index + length <= writerIndex else { return nil }
+        var slice = self
+        slice.base = base + index
+        slice.readerIndex = 0
+        slice.writerIndex = length
         return slice
     }
 
@@ -70,7 +75,8 @@ public struct ByteBuffer: Sendable {
 
     public mutating func readBytes(length: Int) -> [UInt8]? {
         guard readableBytes >= length else { return nil }
-        let result = Array(storage[readerIndex ..< readerIndex + length])
+        let start = base + readerIndex
+        let result = Array(storage[start ..< start + length])
         readerIndex += length
         return result
     }
@@ -80,7 +86,7 @@ public struct ByteBuffer: Sendable {
         guard readableBytes >= size else { return nil }
         var value: T = 0
         for i in 0 ..< size {
-            value = (value << 8) | T(storage[readerIndex + i])
+            value = (value << 8) | T(storage[base + readerIndex + i])
         }
         readerIndex += size
         return value
@@ -90,10 +96,10 @@ public struct ByteBuffer: Sendable {
 
     public func getInteger<T: FixedWidthInteger>(at index: Int, as type: T.Type = T.self) -> T? {
         let size = MemoryLayout<T>.size
-        guard index >= readerIndex, index + size <= writerIndex else { return nil }
+        guard index >= 0, index + size <= writerIndex else { return nil }
         var value: T = 0
         for i in 0 ..< size {
-            value = (value << 8) | T(storage[index + i])
+            value = (value << 8) | T(storage[base + index + i])
         }
         return value
     }
@@ -103,7 +109,7 @@ public struct ByteBuffer: Sendable {
     public func withUnsafeReadableBytes<R, E: Error>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         var captured: Result<R, E>!
         storage.withUnsafeBytes { raw in
-            let readable = UnsafeRawBufferPointer(rebasing: raw[readerIndex ..< writerIndex])
+            let readable = UnsafeRawBufferPointer(rebasing: raw[(base + readerIndex) ..< (base + writerIndex)])
             do throws(E) {
                 captured = .success(try body(readable))
             } catch {
@@ -115,19 +121,20 @@ public struct ByteBuffer: Sendable {
 
     // MARK: Write (advances writerIndex)
 
-    /// Writes `bytes` at `writerIndex`, then advances `writerIndex` past them.
+    /// Writes `bytes` at the physical cursor, then advances `writerIndex`.
     private mutating func writeAtCursor(_ bytes: [UInt8]) {
-        let end = writerIndex + bytes.count
-        if writerIndex == storage.count {
+        let start = base + writerIndex
+        let end = start + bytes.count
+        if start == storage.count {
             storage.append(contentsOf: bytes) // append at end (common case)
         } else if end <= storage.count {
-            storage.replaceSubrange(writerIndex ..< end, with: bytes) // fully overwrite in range
+            storage.replaceSubrange(start ..< end, with: bytes) // fully overwrite in range
         } else {
-            let split = storage.count - writerIndex // overwrite the in-range part
-            storage.replaceSubrange(writerIndex ..< storage.count, with: bytes[..<split])
+            let split = storage.count - start // overwrite the in-range part...
+            storage.replaceSubrange(start ..< storage.count, with: bytes[..<split])
             storage.append(contentsOf: bytes[split...]) // then extend with the rest
         }
-        writerIndex = end
+        writerIndex += bytes.count
     }
 
     @discardableResult
@@ -142,7 +149,8 @@ public struct ByteBuffer: Sendable {
     public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
         let count = buffer.readableBytes
         guard count > 0 else { return 0 }
-        writeAtCursor(Array(buffer.storage[buffer.readerIndex ..< buffer.writerIndex]))
+        let start = buffer.base + buffer.readerIndex
+        writeAtCursor(Array(buffer.storage[start ..< start + count]))
         buffer.readerIndex += count
         return count
     }
@@ -150,11 +158,12 @@ public struct ByteBuffer: Sendable {
     @discardableResult
     public mutating func writeInteger<T: FixedWidthInteger>(_ value: T) -> Int {
         let size = MemoryLayout<T>.size
-        // Big-endian, written byte-by-byte at the cursor
+        // Big-endian.
         for shift in stride(from: (size - 1) * 8, through: 0, by: -8) {
             let byte = UInt8(truncatingIfNeeded: value >> shift)
-            if writerIndex < storage.count {
-                storage[writerIndex] = byte
+            let pos = base + writerIndex
+            if pos < storage.count {
+                storage[pos] = byte
             } else {
                 storage.append(byte)
             }
@@ -166,7 +175,7 @@ public struct ByteBuffer: Sendable {
     @discardableResult
     public mutating func discardReadBytes() -> Bool {
         guard readerIndex > 0 else { return false }
-        storage.removeFirst(readerIndex)
+        storage.removeSubrange(base ..< base + readerIndex)
         writerIndex -= readerIndex
         readerIndex = 0
         return true

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -292,10 +292,9 @@ public struct Inbound<Message: Sendable>: Sendable {
 public struct Outbound<Message: Sendable>: Sendable {
     let writeStep: @Sendable (Message) async -> OutboundStep
 
-    @discardableResult
-    public func write(_ msg: Message) async throws(WendyNetError) -> SendResult {
+    public func write(_ msg: Message) async throws(WendyNetError) {
         switch await writeStep(msg) {
-        case .accepted(let r): return r
+        case .accepted: return
         case .failure(let error): throw error
         }
     }
@@ -330,7 +329,7 @@ enum InboundStep<Message: Sendable>: Sendable {
 }
 
 enum OutboundStep: Sendable {
-    case accepted(SendResult)
+    case accepted
     case failure(WendyNetError)
 }
 
@@ -407,16 +406,6 @@ public final class Channel<Message: Sendable>: Sendable {
         self.remotePeerInfo = remotePeerInfo
         self.core = core
     }
-}
-
-// MARK: - Send Result
-
-public enum SendResult: Sendable {
-    /// The message was accepted and enqueued for transmission.
-    case accepted
-
-    /// The transport discarded the message (e.g. lossy UDP under congestion).
-    case dropped
 }
 
 // MARK: - Transport Info

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -31,51 +31,49 @@ public typealias ByteBuffer = NIOCore.ByteBuffer
 /// Slicing returns a new ByteBuffer that shares backing storage via Swift's
 /// built-in Array CoW.
 public struct ByteBuffer: Sendable {
-    private var _storage: [UInt8] = []
-    private var _readerIndex: Int = 0
-    private var _writerIndex: Int = 0
+    private var storage: [UInt8] = []
+    public private(set) var readerIndex: Int = 0
+    public private(set) var writerIndex: Int = 0
 
-    public var readerIndex: Int { _readerIndex }
-    public var writerIndex: Int { _writerIndex }
-    public var readableBytes: Int { _writerIndex - _readerIndex }
-    public var writableBytes: Int { capacity - _writerIndex }
-    public var capacity: Int { _storage.count }
+    public var readableBytes: Int { writerIndex - readerIndex }
+    public var writableBytes: Int { capacity - writerIndex }
+    public var capacity: Int { storage.count }
 
     public init() {}
 
     public init(bytes: [UInt8]) {
-        _storage = bytes
-        _writerIndex = bytes.count
+        storage = bytes
+        writerIndex = bytes.count
     }
 
     // MARK: Slicing (shares storage, no copy)
 
     public func getSlice(at index: Int, length: Int) -> ByteBuffer? {
-        guard index >= _readerIndex, index + length <= _writerIndex else { return nil }
+        guard index >= readerIndex, index + length <= writerIndex else { return nil }
         var slice = ByteBuffer()
-        slice._storage = _storage
-        slice._readerIndex = index
-        slice._writerIndex = index + length
+        slice.storage = storage
+        slice.readerIndex = index
+        slice.writerIndex = index + length
         return slice
     }
 
     public mutating func readSlice(length: Int) -> ByteBuffer? {
         guard readableBytes >= length else { return nil }
-        let slice = getSlice(at: _readerIndex, length: length)
-        _readerIndex += length
+        let slice = getSlice(at: readerIndex, length: length)
+        readerIndex += length
         return slice
     }
 
     public mutating func moveReaderIndex(forwardBy count: Int) {
-        _readerIndex += count
+        readerIndex += count
     }
 
     // MARK: Copying reads (advance readerIndex)
 
     public mutating func readBytes(length: Int) -> [UInt8]? {
         guard readableBytes >= length else { return nil }
-        let result = Array(_storage[_readerIndex ..< _readerIndex + length])
-        _readerIndex += length
+        let result = Array(storage[readerIndex ..< readerIndex + length])
+        readerIndex += length
         return result
     }
 
@@ -84,9 +82,9 @@ public struct ByteBuffer: Sendable {
         guard readableBytes >= size else { return nil }
         var value: T = 0
         for i in 0 ..< size {
-            value = (value << 8) | T(_storage[_readerIndex + i])
+            value = (value << 8) | T(storage[readerIndex + i])
         }
-        _readerIndex += size
+        readerIndex += size
         return value
     }
 
@@ -94,10 +92,10 @@ public struct ByteBuffer: Sendable {
 
     public func getInteger<T: FixedWidthInteger>(at index: Int, as type: T.Type = T.self) -> T? {
         let size = MemoryLayout<T>.size
-        guard index >= _readerIndex, index + size <= _writerIndex else { return nil }
+        guard index >= readerIndex, index + size <= writerIndex else { return nil }
         var value: T = 0
         for i in 0 ..< size {
-            value = (value << 8) | T(_storage[index + i])
+            value = (value << 8) | T(storage[index + i])
         }
         return value
     }
@@ -106,8 +104,8 @@ public struct ByteBuffer: Sendable {
     /// is only valid for the duration of `body`.
     public func withUnsafeReadableBytes<R, E: Error>(_ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R {
         var captured: Result<R, E>!
-        _storage.withUnsafeBytes { raw in
-            let readable = UnsafeRawBufferPointer(rebasing: raw[_readerIndex ..< _writerIndex])
+        storage.withUnsafeBytes { raw in
+            let readable = UnsafeRawBufferPointer(rebasing: raw[readerIndex ..< writerIndex])
             do throws(E) {
                 captured = .success(try body(readable))
             } catch {
@@ -121,8 +119,8 @@ public struct ByteBuffer: Sendable {
 
     @discardableResult
     public mutating func writeBytes(_ bytes: [UInt8]) -> Int {
-        _storage.append(contentsOf: bytes)
-        _writerIndex += bytes.count
+        storage.append(contentsOf: bytes)
+        writerIndex += bytes.count
         return bytes.count
     }
 
@@ -131,9 +129,9 @@ public struct ByteBuffer: Sendable {
     public mutating func writeBuffer(_ buffer: inout ByteBuffer) -> Int {
         let count = buffer.readableBytes
         guard count > 0 else { return 0 }
-        _storage.append(contentsOf: buffer._storage[buffer._readerIndex ..< buffer._writerIndex])
-        _writerIndex += count
-        buffer._readerIndex += count
+        storage.append(contentsOf: buffer.storage[buffer.readerIndex ..< buffer.writerIndex])
+        writerIndex += count
+        buffer.readerIndex += count
         return count
     }
 
@@ -141,18 +139,18 @@ public struct ByteBuffer: Sendable {
     public mutating func writeInteger<T: FixedWidthInteger>(_ value: T) -> Int {
         let size = MemoryLayout<T>.size
         for i in (0 ..< size).reversed() {
-            _storage.append(UInt8(truncatingIfNeeded: value >> (i * 8)))
+            storage.append(UInt8(truncatingIfNeeded: value >> (i * 8)))
         }
-        _writerIndex += size
+        writerIndex += size
         return size
     }
 
     @discardableResult
     public mutating func discardReadBytes() -> Bool {
-        guard _readerIndex > 0 else { return false }
-        _storage.removeFirst(_readerIndex)
-        _writerIndex -= _readerIndex
-        _readerIndex = 0
+        guard readerIndex > 0 else { return false }
+        storage.removeFirst(readerIndex)
+        writerIndex -= readerIndex
+        readerIndex = 0
         return true
     }
 }
@@ -275,10 +273,10 @@ public struct PipelineBuilder {
 /// from a concurrent context that contends with another such call throws
 /// `WendyNetError.concurrentAccess`.
 public struct Inbound<Message: Sendable>: Sendable {
-    let _next: @Sendable () async -> InboundStep<Message>
+    let nextStep: @Sendable () async -> InboundStep<Message>
 
     public func next() async throws(WendyNetError) -> Message? {
-        switch await _next() {
+        switch await nextStep() {
         case .message(let m): return m
         case .end: return nil
         case .failure(let error): throw error
@@ -292,11 +290,11 @@ public struct Inbound<Message: Sendable>: Sendable {
 /// send is suspended (waiting for backpressure relief or transport completion)
 /// it throws `.cancelled`.
 public struct Outbound<Message: Sendable>: Sendable {
-    let _write: @Sendable (Message) async -> OutboundStep
+    let writeStep: @Sendable (Message) async -> OutboundStep
 
     @discardableResult
     public func write(_ msg: Message) async throws(WendyNetError) -> SendResult {
-        switch await _write(msg) {
+        switch await writeStep(msg) {
         case .accepted(let r): return r
         case .failure(let error): throw error
         }
@@ -313,10 +311,10 @@ public struct Outbound<Message: Sendable>: Sendable {
 /// from a concurrent context that contends with another such call throws
 /// `WendyNetError.concurrentAccess`.
 public struct Accepted<Message: Sendable>: Sendable {
-    let _next: @Sendable () async -> AcceptedStep<Message>
+    let nextStep: @Sendable () async -> AcceptedStep<Message>
 
     public func next() async throws(WendyNetError) -> Channel<Message>? {
-        switch await _next() {
+        switch await nextStep() {
         case .channel(let c): return c
         case .end: return nil
         case .failure(let error): throw error
@@ -377,7 +375,7 @@ public final class Channel<Message: Sendable>: Sendable {
     /// Present after mTLS handshake with a Wendy peer.
     public let remotePeerInfo: PeerInfo?
 
-    let _core: ChannelCore<Message>?
+    let core: ChannelCore<Message>?
 
     /// Drive the channel inside a structured scope.
     ///
@@ -390,7 +388,7 @@ public final class Channel<Message: Sendable>: Sendable {
     public func executeThenClose<R: Sendable>(
         _ body: @Sendable (Inbound<Message>, Outbound<Message>) async throws(WendyNetError) -> R
     ) async throws(WendyNetError) -> R {
-        guard let core = _core else {
+        guard let core = core else {
             throw .connectionFailed
         }
         return try await core.executeThenClose(body)
@@ -407,7 +405,7 @@ public final class Channel<Message: Sendable>: Sendable {
         self.transport = transport
         self.maximumMessageLength = maximumMessageLength
         self.remotePeerInfo = remotePeerInfo
-        self._core = core
+        self.core = core
     }
 }
 
@@ -521,25 +519,25 @@ public final class Listener<Message: Sendable>: Sendable {
 // MARK: - Pipeline Closures
 
 /// Closure bundle produced by a pipeline factory.
-struct _PipelineClosures<Message> {
+struct PipelineClosures<Message> {
     let decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
     let encode: (Message) -> ByteBuffer
     let started: (ConnectionContext) -> Void
 }
 
 /// Closure bundle for a framer (ByteBuffer -> ByteBuffer, stream transports only).
-struct _FramerClosures {
+struct FramerClosures {
     let decode: (ByteBuffer, (ByteBuffer) -> Void, (WendyNetError) -> Void) -> Void
     let encode: (ByteBuffer) -> ByteBuffer
     let started: (ConnectionContext) -> Void
 
     /// Wrap a pipeline's closures so the framer runs first on inbound
     /// and last on outbound.
-    func composing<Message>(_ inner: _PipelineClosures<Message>) -> _PipelineClosures<Message> {
+    func composing<Message>(_ inner: PipelineClosures<Message>) -> PipelineClosures<Message> {
         let framerDecode = self.decode
         let framerEncode = self.encode
         let framerStarted = self.started
-        return _PipelineClosures<Message>(
+        return PipelineClosures<Message>(
             decode: { buf, emit, fail in
                 framerDecode(buf, { frameBuf in
                     inner.decode(frameBuf, emit, fail)
@@ -559,17 +557,17 @@ struct _FramerClosures {
 // MARK: - Bootstrap configuration
 
 /// Shared configuration backing both `ClientBootstrap` and `ServerBootstrap`.
-struct _BootstrapConfig<Message: Sendable>: Sendable {
+struct BootstrapConfig<Message: Sendable>: Sendable {
     var security: SecurityMode = .insecure
     var udpAssociationTimeoutSeconds: Int = 60
-    let pipelineFactory: @Sendable () -> _PipelineClosures<Message>
-    var framerFactory: (@Sendable () -> _FramerClosures)? = nil
+    let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    var framerFactory: (@Sendable () -> FramerClosures)? = nil
 
     /// The identity pipeline: raw bytes through, no decode/encode transform.
-    static func passthrough() -> _BootstrapConfig<ByteBuffer> {
-        _BootstrapConfig<ByteBuffer>(
+    static func passthrough() -> BootstrapConfig<ByteBuffer> {
+        BootstrapConfig<ByteBuffer>(
             pipelineFactory: {
-                _PipelineClosures(
+                PipelineClosures(
                     decode: { buf, emit, _ in emit(buf) },
                     encode: { $0 },
                     started: { _ in }
@@ -582,9 +580,9 @@ struct _BootstrapConfig<Message: Sendable>: Sendable {
     /// factory while preserving every other field (so `.pipeline()` can't drop
     /// a previously configured option).
     func reframed<New: Sendable>(
-        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<New>
-    ) -> _BootstrapConfig<New> {
-        _BootstrapConfig<New>(
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<New>
+    ) -> BootstrapConfig<New> {
+        BootstrapConfig<New>(
             security: security,
             udpAssociationTimeoutSeconds: udpAssociationTimeoutSeconds,
             pipelineFactory: pipelineFactory,
@@ -594,12 +592,12 @@ struct _BootstrapConfig<Message: Sendable>: Sendable {
 }
 
 /// Wrap a `PipelineStage` factory into framer closures.
-private func _makeFramerClosures<F: PipelineStage & SendableMetatype>(
+private func makeFramerClosures<F: PipelineStage & SendableMetatype>(
     _ factory: @escaping @Sendable () -> F
-) -> @Sendable () -> _FramerClosures where F.Input == ByteBuffer, F.Output == ByteBuffer {
+) -> @Sendable () -> FramerClosures where F.Input == ByteBuffer, F.Output == ByteBuffer {
     {
         let framer = factory()
-        return _FramerClosures(
+        return FramerClosures(
             decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
             encode: { buf in framer.encode(buf) },
             started: { context in framer.started(context: context) }
@@ -608,12 +606,12 @@ private func _makeFramerClosures<F: PipelineStage & SendableMetatype>(
 }
 
 /// Wrap a `PipelineStage` factory into pipeline closures.
-private func _makePipelineClosures<P: PipelineStage & SendableMetatype>(
+private func makePipelineClosures<P: PipelineStage & SendableMetatype>(
     _ build: @escaping @Sendable () -> P
-) -> @Sendable () -> _PipelineClosures<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
+) -> @Sendable () -> PipelineClosures<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
     {
         let pipeline = build()
-        return _PipelineClosures(
+        return PipelineClosures(
             decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
             encode: { msg in pipeline.encode(msg) },
             started: { context in pipeline.started(context: context) }
@@ -636,13 +634,13 @@ private func _makePipelineClosures<P: PipelineStage & SendableMetatype>(
 /// `connect(to:)` lives in the active backend file.
 public struct ClientBootstrap<Message: Sendable>: Sendable {
     let wendyNet: WendyNet
-    var config: _BootstrapConfig<Message>
+    var config: BootstrapConfig<Message>
 
     // Accessors used by the backend `connect(to:)` extensions.
     var security: SecurityMode { config.security }
     var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
-    var _pipelineFactory: @Sendable () -> _PipelineClosures<Message> { config.pipelineFactory }
-    var _framerFactory: (@Sendable () -> _FramerClosures)? { config.framerFactory }
+    var pipelineFactory: @Sendable () -> PipelineClosures<Message> { config.pipelineFactory }
+    var framerFactory: (@Sendable () -> FramerClosures)? { config.framerFactory }
 
     /// Create a bootstrap with no pipeline. Produces Channel<ByteBuffer>.
     public init(wendyNet: WendyNet) where Message == ByteBuffer {
@@ -650,7 +648,7 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
         self.config = .passthrough()
     }
 
-    init(wendyNet: WendyNet, config: _BootstrapConfig<Message>) {
+    init(wendyNet: WendyNet, config: BootstrapConfig<Message>) {
         self.wendyNet = wendyNet
         self.config = config
     }
@@ -673,7 +671,7 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
         _ factory: @escaping @Sendable () -> F
     ) -> ClientBootstrap where F.Input == ByteBuffer, F.Output == ByteBuffer {
         var copy = self
-        copy.config.framerFactory = _makeFramerClosures(factory)
+        copy.config.framerFactory = makeFramerClosures(factory)
         return copy
     }
 
@@ -684,7 +682,7 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
     ) -> ClientBootstrap<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
         ClientBootstrap<P.Output>(
             wendyNet: wendyNet,
-            config: config.reframed(pipelineFactory: _makePipelineClosures(build))
+            config: config.reframed(pipelineFactory: makePipelineClosures(build))
         )
     }
 }
@@ -696,20 +694,20 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
 /// `bind(port:)` lives in the active backend file.
 public struct ServerBootstrap<Message: Sendable>: Sendable {
     let wendyNet: WendyNet
-    var config: _BootstrapConfig<Message>
+    var config: BootstrapConfig<Message>
 
     // Accessors used by the backend `bind(port:)` extensions.
     var security: SecurityMode { config.security }
     var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
-    var _pipelineFactory: @Sendable () -> _PipelineClosures<Message> { config.pipelineFactory }
-    var _framerFactory: (@Sendable () -> _FramerClosures)? { config.framerFactory }
+    var pipelineFactory: @Sendable () -> PipelineClosures<Message> { config.pipelineFactory }
+    var framerFactory: (@Sendable () -> FramerClosures)? { config.framerFactory }
 
     public init(wendyNet: WendyNet) where Message == ByteBuffer {
         self.wendyNet = wendyNet
         self.config = .passthrough()
     }
 
-    init(wendyNet: WendyNet, config: _BootstrapConfig<Message>) {
+    init(wendyNet: WendyNet, config: BootstrapConfig<Message>) {
         self.wendyNet = wendyNet
         self.config = config
     }
@@ -731,7 +729,7 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
         _ factory: @escaping @Sendable () -> F
     ) -> ServerBootstrap where F.Input == ByteBuffer, F.Output == ByteBuffer {
         var copy = self
-        copy.config.framerFactory = _makeFramerClosures(factory)
+        copy.config.framerFactory = makeFramerClosures(factory)
         return copy
     }
 
@@ -742,7 +740,7 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
     ) -> ServerBootstrap<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
         ServerBootstrap<P.Output>(
             wendyNet: wendyNet,
-            config: config.reframed(pipelineFactory: _makePipelineClosures(build))
+            config: config.reframed(pipelineFactory: makePipelineClosures(build))
         )
     }
 }

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -166,7 +166,6 @@ private final class AcceptIteratorBox<Message: Sendable>: Sendable {
         // seeing nil here surfaces `.concurrentAccess` to the caller.
         var iterator: NIOAsyncChannelInboundStream<NIOByteBufferChannel>.AsyncIterator?
         var ended = false
-        var error: WendyNetError? = nil
     }
     private let state: LockedBox<State>
     private let context: ConnectionContext
@@ -188,7 +187,6 @@ private final class AcceptIteratorBox<Message: Sendable>: Sendable {
     func next() async -> AcceptedStep<Message> {
         // Fast path: terminal state.
         let fast: AcceptedStep<Message>? = state.withLockedValue { s in
-            if let err = s.error { return .failure(err) }
             if s.ended { return .end }
             return nil
         }

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -324,7 +324,7 @@ final class ChannelCore<Message: Sendable>: Sendable {
                         } catch {
                             return .failure(.connectionFailed)
                         }
-                        return .accepted(.accepted)
+                        return .accepted
                     }
                 )
 

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -39,26 +39,60 @@ private let standardEventLoopGroup = MultiThreadedEventLoopGroup.singleton
 fileprivate typealias NIOByteBufferChannel = NIOAsyncChannel<ByteBuffer, ByteBuffer>
 fileprivate typealias NIOServerInboundChannel = NIOAsyncChannel<NIOByteBufferChannel, Never>
 
-// MARK: - Inbound bridge
+// MARK: - Inbound / outbound bridges
 
-private final class _ByteBufferInboundBridge<Message: Sendable>: Sendable {
+/// Pulls `ByteBuffer`s from a NIO async-channel inbound stream, enforcing the
+/// single-consumer contract: a second concurrent pull observing the claimed-out
+/// iterator surfaces `.concurrentAccess`.
+private final class _NIOByteSource: Sendable {
     private struct State {
-        // `iterator` is briefly set to nil while a (single) caller is awaiting
-        // the next NIO buffer outside the lock. A second concurrent `next()`
-        // call seeing nil here surfaces `.concurrentAccess` to the caller.
         var iterator: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator?
+    }
+    private let state: _LockedBox<State>
+
+    init(iterator: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator) {
+        self.state = _LockedBox(State(iterator: iterator))
+    }
+
+    func pull() async -> Result<ByteBuffer?, WendyNetError> {
+        let claimed: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator? =
+            state.withLockedValue { s in
+                let i = s.iterator
+                s.iterator = nil
+                return i
+            }
+        guard var iter = claimed else {
+            return .failure(.concurrentAccess)
+        }
+        let result: Result<ByteBuffer?, WendyNetError>
+        do {
+            result = .success(try await iter.next())
+        } catch is CancellationError {
+            result = .failure(.cancelled)
+        } catch {
+            result = .failure(.connectionFailed)
+        }
+        state.withLockedValue { s in s.iterator = iter }
+        return result
+    }
+}
+
+private final class _InboundBridge<Message: Sendable>: Sendable {
+    private struct State {
         var pending: [Message] = []
         var error: WendyNetError? = nil
         var ended = false
         var decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
     }
     private let state: _LockedBox<State>
+    private let pull: @Sendable () async -> Result<ByteBuffer?, WendyNetError>
 
     init(
-        iterator: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator,
-        decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
+        decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
+        pull: @escaping @Sendable () async -> Result<ByteBuffer?, WendyNetError>
     ) {
-        self.state = _LockedBox(State(iterator: iterator, decode: decode))
+        self.state = _LockedBox(State(decode: decode))
+        self.pull = pull
     }
 
     func next() async -> InboundStep<Message> {
@@ -72,36 +106,16 @@ private final class _ByteBufferInboundBridge<Message: Sendable>: Sendable {
             }
             if let fast { return fast }
 
-            // Claim the iterator out of the box. If it's already nil another
-            // caller is awaiting -- single-consumer contract violated; surface
-            // as `.concurrentAccess`.
-            let claimed: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator? = state.withLockedValue { s in
-                let i = s.iterator
-                s.iterator = nil
-                return i
-            }
-            guard var iter = claimed else {
-                return .failure(.concurrentAccess)
-            }
-
-            // Await outside the lock.
-            let pull: Result<ByteBuffer?, Error>
-            do {
-                let buf = try await iter.next()
-                pull = .success(buf)
-            } catch {
-                pull = .failure(error)
-            }
+            let pulled = await pull()
 
             let result: InboundStep<Message>? = state.withLockedValue { s in
-                s.iterator = iter
-                switch pull {
+                switch pulled {
                 case .success(let bufOpt):
                     guard let buf = bufOpt else {
                         s.ended = true
                         return .end
                     }
-                    // Zero-copy hand-off: pipeline sees NIO's buffer directly.
+                    // Zero-copy hand-off: pipeline sees the source buffer directly.
                     s.decode(buf, { msg in
                         s.pending.append(msg)
                     }, { err in
@@ -109,13 +123,10 @@ private final class _ByteBufferInboundBridge<Message: Sendable>: Sendable {
                     })
                     if let err = s.error { return .failure(err) }
                     if !s.pending.isEmpty { return .message(s.pending.removeFirst()) }
-                    return nil  // loop to deliver from buffered state
+                    return nil  // decoded zero messages; pull again
                 case .failure(let err):
                     s.ended = true
-                    if err is CancellationError {
-                        return .failure(.cancelled)
-                    }
-                    return .failure(.connectionFailed)
+                    return .failure(err)
                 }
             }
             if let result { return result }
@@ -123,34 +134,26 @@ private final class _ByteBufferInboundBridge<Message: Sendable>: Sendable {
     }
 }
 
-// MARK: - Outbound bridge
-
-private final class _ByteBufferOutboundBridge<Message: Sendable>: Sendable {
+private final class _OutboundBridge<Message: Sendable>: Sendable {
     private struct State {
         var encode: (Message) -> ByteBuffer
     }
     private let state: _LockedBox<State>
-    fileprivate let nioOutbound: NIOAsyncChannelOutboundWriter<ByteBuffer>
+    private let sink: @Sendable (ByteBuffer) async -> OutboundStep
 
     init(
-        nioOutbound: NIOAsyncChannelOutboundWriter<ByteBuffer>,
-        encode: @escaping (Message) -> ByteBuffer
+        encode: @escaping (Message) -> ByteBuffer,
+        sink: @escaping @Sendable (ByteBuffer) async -> OutboundStep
     ) {
-        self.nioOutbound = nioOutbound
         self.state = _LockedBox(State(encode: encode))
+        self.sink = sink
     }
 
     func write(_ msg: Message) async -> OutboundStep {
-        // Zero-copy hand-off: pipeline-produced buffer goes straight to NIO.
+        // Encode under lock (may mutate user stage state); the CoW buffer then
+        // travels to the sink without copying.
         let buf = state.withLockedValue { s in s.encode(msg) }
-        do {
-            try await nioOutbound.write(buf)
-        } catch is CancellationError {
-            return .failure(.cancelled)
-        } catch {
-            return .failure(.connectionFailed)
-        }
-        return .accepted(.accepted)
+        return await sink(buf)
     }
 }
 
@@ -306,13 +309,23 @@ final class ChannelCore<Message: Sendable>: Sendable {
         let outcome: Result<R, WendyNetError>
         do {
             outcome = try await nioAsyncChannel.executeThenClose { nioInbound, nioOutbound -> Result<R, WendyNetError> in
-                let inboundBridge = _ByteBufferInboundBridge<Message>(
-                    iterator: nioInbound.makeAsyncIterator(),
-                    decode: decodeClosure
+                let source = _NIOByteSource(iterator: nioInbound.makeAsyncIterator())
+                let inboundBridge = _InboundBridge<Message>(
+                    decode: decodeClosure,
+                    pull: { [source] in await source.pull() }
                 )
-                let outboundBridge = _ByteBufferOutboundBridge<Message>(
-                    nioOutbound: nioOutbound,
-                    encode: encodeClosure
+                let outboundBridge = _OutboundBridge<Message>(
+                    encode: encodeClosure,
+                    sink: { [nioOutbound] buf in
+                        do {
+                            try await nioOutbound.write(buf)
+                        } catch is CancellationError {
+                            return .failure(.cancelled)
+                        } catch {
+                            return .failure(.connectionFailed)
+                        }
+                        return .accepted(.accepted)
+                    }
                 )
 
                 let inbound = Inbound<Message>(_next: { [inboundBridge] in

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -19,7 +19,7 @@ import _Concurrency
 // and would not accept our `State` containing non-`Sendable` user closures,
 // which is why we need this carrier rather than NIO's stock primitive.
 
-fileprivate final class _LockedBox<T>: @unchecked Sendable {
+fileprivate final class LockedBox<T>: @unchecked Sendable {
     private let lock = NIOLock()
     private var value: T
 
@@ -44,14 +44,14 @@ fileprivate typealias NIOServerInboundChannel = NIOAsyncChannel<NIOByteBufferCha
 /// Pulls `ByteBuffer`s from a NIO async-channel inbound stream, enforcing the
 /// single-consumer contract: a second concurrent pull observing the claimed-out
 /// iterator surfaces `.concurrentAccess`.
-private final class _NIOByteSource: Sendable {
+private final class NIOByteSource: Sendable {
     private struct State {
         var iterator: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator?
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
 
     init(iterator: NIOAsyncChannelInboundStream<ByteBuffer>.AsyncIterator) {
-        self.state = _LockedBox(State(iterator: iterator))
+        self.state = LockedBox(State(iterator: iterator))
     }
 
     func pull() async -> Result<ByteBuffer?, WendyNetError> {
@@ -77,21 +77,21 @@ private final class _NIOByteSource: Sendable {
     }
 }
 
-private final class _InboundBridge<Message: Sendable>: Sendable {
+private final class InboundBridge<Message: Sendable>: Sendable {
     private struct State {
         var pending: [Message] = []
         var error: WendyNetError? = nil
         var ended = false
         var decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
     private let pull: @Sendable () async -> Result<ByteBuffer?, WendyNetError>
 
     init(
         decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
         pull: @escaping @Sendable () async -> Result<ByteBuffer?, WendyNetError>
     ) {
-        self.state = _LockedBox(State(decode: decode))
+        self.state = LockedBox(State(decode: decode))
         self.pull = pull
     }
 
@@ -134,18 +134,18 @@ private final class _InboundBridge<Message: Sendable>: Sendable {
     }
 }
 
-private final class _OutboundBridge<Message: Sendable>: Sendable {
+private final class OutboundBridge<Message: Sendable>: Sendable {
     private struct State {
         var encode: (Message) -> ByteBuffer
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
     private let sink: @Sendable (ByteBuffer) async -> OutboundStep
 
     init(
         encode: @escaping (Message) -> ByteBuffer,
         sink: @escaping @Sendable (ByteBuffer) async -> OutboundStep
     ) {
-        self.state = _LockedBox(State(encode: encode))
+        self.state = LockedBox(State(encode: encode))
         self.sink = sink
     }
 
@@ -159,7 +159,7 @@ private final class _OutboundBridge<Message: Sendable>: Sendable {
 
 // MARK: - Accept bridge
 
-private final class _AcceptIteratorBox<Message: Sendable>: Sendable {
+private final class AcceptIteratorBox<Message: Sendable>: Sendable {
     private struct State {
         // `iterator` is briefly nil while a (single) caller is awaiting the
         // next accepted connection outside the lock; a second concurrent call
@@ -168,18 +168,18 @@ private final class _AcceptIteratorBox<Message: Sendable>: Sendable {
         var ended = false
         var error: WendyNetError? = nil
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
     private let context: ConnectionContext
-    private let pipelineFactory: @Sendable () -> _PipelineClosures<Message>
-    private let framerFactory: (@Sendable () -> _FramerClosures)?
+    private let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    private let framerFactory: (@Sendable () -> FramerClosures)?
 
     init(
         iterator: NIOAsyncChannelInboundStream<NIOByteBufferChannel>.AsyncIterator,
         context: ConnectionContext,
-        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<Message>,
-        framerFactory: (@Sendable () -> _FramerClosures)?
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<Message>,
+        framerFactory: (@Sendable () -> FramerClosures)?
     ) {
-        self.state = _LockedBox(State(iterator: iterator))
+        self.state = LockedBox(State(iterator: iterator))
         self.context = context
         self.pipelineFactory = pipelineFactory
         self.framerFactory = framerFactory
@@ -258,7 +258,7 @@ private final class _AcceptIteratorBox<Message: Sendable>: Sendable {
 
 // MARK: - ChannelCore
 //
-// Sendable. The non-Sendable pipeline closures live inside `_LockedBox<Closures?>`
+// Sendable. The non-Sendable pipeline closures live inside `LockedBox<Closures?>`
 // and are consumed (set to nil) on the first call to `executeThenClose`,
 // after which the bridges own them. A second call sees nil and fatal-errors:
 // `executeThenClose` is documented as one-shot, and two concurrent calls
@@ -274,7 +274,7 @@ final class ChannelCore<Message: Sendable>: Sendable {
         let decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
         let encode: (Message) -> ByteBuffer
     }
-    private let closures: _LockedBox<Closures?>
+    private let closures: LockedBox<Closures?>
 
     fileprivate init(
         nioAsyncChannel: NIOByteBufferChannel,
@@ -286,7 +286,7 @@ final class ChannelCore<Message: Sendable>: Sendable {
         self.nioAsyncChannel = nioAsyncChannel
         self.endpoint = endpoint
         self.transport = transport
-        self.closures = _LockedBox(Closures(decode: decode, encode: encode))
+        self.closures = LockedBox(Closures(decode: decode, encode: encode))
     }
 
     func executeThenClose<R: Sendable>(
@@ -309,12 +309,12 @@ final class ChannelCore<Message: Sendable>: Sendable {
         let outcome: Result<R, WendyNetError>
         do {
             outcome = try await nioAsyncChannel.executeThenClose { nioInbound, nioOutbound -> Result<R, WendyNetError> in
-                let source = _NIOByteSource(iterator: nioInbound.makeAsyncIterator())
-                let inboundBridge = _InboundBridge<Message>(
+                let source = NIOByteSource(iterator: nioInbound.makeAsyncIterator())
+                let inboundBridge = InboundBridge<Message>(
                     decode: decodeClosure,
                     pull: { [source] in await source.pull() }
                 )
-                let outboundBridge = _OutboundBridge<Message>(
+                let outboundBridge = OutboundBridge<Message>(
                     encode: encodeClosure,
                     sink: { [nioOutbound] buf in
                         do {
@@ -328,10 +328,10 @@ final class ChannelCore<Message: Sendable>: Sendable {
                     }
                 )
 
-                let inbound = Inbound<Message>(_next: { [inboundBridge] in
+                let inbound = Inbound<Message>(nextStep: { [inboundBridge] in
                     await inboundBridge.next()
                 })
-                let outbound = Outbound<Message>(_write: { [outboundBridge] msg in
+                let outbound = Outbound<Message>(writeStep: { [outboundBridge] msg in
                     await outboundBridge.write(msg)
                 })
 
@@ -361,17 +361,17 @@ final class ListenerCore<Message: Sendable>: Sendable {
     let port: UInt16
     let context: ConnectionContext
     fileprivate let serverChannel: NIOServerInboundChannel
-    private let pipelineFactory: @Sendable () -> _PipelineClosures<Message>
-    private let framerFactory: (@Sendable () -> _FramerClosures)?
+    private let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    private let framerFactory: (@Sendable () -> FramerClosures)?
     /// Single-use latch -- see `executeThenClose` for rationale.
-    private let used = _LockedBox<Bool>(false)
+    private let used = LockedBox<Bool>(false)
 
     fileprivate init(
         port: UInt16,
         context: ConnectionContext,
         serverChannel: NIOServerInboundChannel,
-        pipelineFactory: @escaping @Sendable () -> _PipelineClosures<Message>,
-        framerFactory: (@Sendable () -> _FramerClosures)?
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<Message>,
+        framerFactory: (@Sendable () -> FramerClosures)?
     ) {
         self.port = port
         self.context = context
@@ -403,13 +403,13 @@ final class ListenerCore<Message: Sendable>: Sendable {
         let outcome: Result<R, WendyNetError>
         do {
             outcome = try await serverChannel.executeThenClose { acceptStream -> Result<R, WendyNetError> in
-                let bridge = _AcceptIteratorBox<Message>(
+                let bridge = AcceptIteratorBox<Message>(
                     iterator: acceptStream.makeAsyncIterator(),
                     context: context,
                     pipelineFactory: pipelineFactory,
                     framerFactory: framerFactory
                 )
-                let accepted = Accepted<Message>(_next: { [bridge] in
+                let accepted = Accepted<Message>(nextStep: { [bridge] in
                     await bridge.next()
                 })
 
@@ -450,8 +450,8 @@ extension ClientBootstrap {
         }
 
         let transport = TransportInfo(kind: .tcp, isStream: true)
-        var closures = _pipelineFactory()
-        if let framerFactory = _framerFactory {
+        var closures = pipelineFactory()
+        if let framerFactory = framerFactory {
             closures = framerFactory().composing(closures)
         }
 
@@ -498,8 +498,8 @@ extension ServerBootstrap {
         let endpoint = Endpoint.ipHost(hostname: "0.0.0.0", port: port)
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
 
-        let pipelineFactory = self._pipelineFactory
-        let framerFactory = self._framerFactory
+        let pipelineFactory = self.pipelineFactory
+        let framerFactory = self.framerFactory
 
         let serverChannel: NIOServerInboundChannel
         do {

--- a/Sources/WendyNet/Backend+WendyLite.swift
+++ b/Sources/WendyNet/Backend+WendyLite.swift
@@ -6,7 +6,7 @@ import _Concurrency
 
 // MARK: - Internal lock primitive
 //
-// `_LockedBox<T>` is a lock-protected carrier for mutable state. It plays
+// `LockedBox<T>` is a lock-protected carrier for mutable state. It plays
 // the combined role of SwiftNIO's `NIOLockedValueBox` (lock-protected
 // mutation of `Sendable` state) and `NIOLoopBoundBox` (carrier of
 // non-`Sendable` state confined by external discipline). The second role
@@ -49,7 +49,7 @@ import _Concurrency
 // ever gains pre-emptive scheduling or multi-threaded executors, the code
 // still works.
 
-fileprivate final class _LockedBox<T>: @unchecked Sendable {
+fileprivate final class LockedBox<T>: @unchecked Sendable {
     private let locked = Atomic<Bool>(false)
     private var value: T
 
@@ -81,8 +81,8 @@ fileprivate final class _LockedBox<T>: @unchecked Sendable {
 //   poll:         ready value, or nil to park
 //   park:         store the continuation, or return a value (e.g. concurrentAccess)
 //   cancelWaiter: take and clear the parked continuation
-private func _parkOrResume<S, R: Sendable>(
-    _ box: _LockedBox<S>,
+private func parkOrResume<S, R: Sendable>(
+    _ box: LockedBox<S>,
     cancelled: R,
     poll: @escaping @Sendable (inout S) -> R?,
     park: @escaping @Sendable (inout S, CheckedContinuation<R, Never>) -> R?,
@@ -213,7 +213,7 @@ fileprivate final class WendyNetHub: Sendable {
         var isDraining = false
         var initialized = false
     }
-    private let state = _LockedBox(State())
+    private let state = LockedBox(State())
 
     func ensureInitialized() -> Bool {
         state.withLockedValue { s in
@@ -300,17 +300,17 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
         var pendingChannels: [Channel<Message>] = []
         var acceptWaiter: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>? = nil
         var isClosed = false
-        var closures: _PipelineClosures<Message>
+        var closures: PipelineClosures<Message>
         /// Single-use latch -- see `executeThenClose` for rationale.
         var executeThenCloseUsed = false
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
 
-    init(handle: Int32, port: UInt16, context: ConnectionContext, closures: _PipelineClosures<Message>) {
+    init(handle: Int32, port: UInt16, context: ConnectionContext, closures: PipelineClosures<Message>) {
         self.handle = handle
         self.port = port
         self.context = context
-        self.state = _LockedBox(State(closures: closures))
+        self.state = LockedBox(State(closures: closures))
     }
 
     private func accept() async throws(WendyNetError) -> Channel<Message>? {
@@ -329,7 +329,7 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
 
         drainAccepted()
 
-        let result = await _parkOrResume(
+        let result = await parkOrResume(
             state,
             cancelled: Result<Channel<Message>?, WendyNetError>.failure(.cancelled),
             poll: { s in
@@ -367,7 +367,7 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
             throw .alreadyConsumed
         }
 
-        let accepted = Accepted<Message>(_next: { [self] in
+        let accepted = Accepted<Message>(nextStep: { [self] in
             do throws(WendyNetError) {
                 if let channel = try await accept() {
                     return .channel(channel)
@@ -486,7 +486,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         /// Single-use latch -- see `executeThenClose` for rationale.
         var executeThenCloseUsed = false
     }
-    private let state: _LockedBox<State>
+    private let state: LockedBox<State>
 
     init(
         handle: Int32,
@@ -498,7 +498,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         self.handle = handle
         self.endpoint = endpoint
         self.transport = transport
-        self.state = _LockedBox(State(decode: decode, encode: encode))
+        self.state = LockedBox(State(decode: decode, encode: encode))
     }
 
     private func receive() async throws(WendyNetError) -> Message? {
@@ -511,7 +511,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         }
         drainReadable()
 
-        let result = await _parkOrResume(
+        let result = await parkOrResume(
             state,
             cancelled: Result<Message?, WendyNetError>.failure(.cancelled),
             poll: { s in
@@ -635,7 +635,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
             throw .alreadyConsumed
         }
 
-        let inbound = Inbound<Message>(_next: { [self] in
+        let inbound = Inbound<Message>(nextStep: { [self] in
             do throws(WendyNetError) {
                 if let msg = try await receive() {
                     return .message(msg)
@@ -645,7 +645,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 return .failure(error)
             }
         })
-        let outbound = Outbound<Message>(_write: { [self] msg in
+        let outbound = Outbound<Message>(writeStep: { [self] msg in
             do throws(WendyNetError) {
                 let result = try await send(msg)
                 return .accepted(result)
@@ -894,8 +894,8 @@ extension ClientBootstrap {
         }
 
         let transport = TransportInfo(kind: .tcp, isStream: true)
-        var closures = _pipelineFactory()
-        if let framerFactory = _framerFactory {
+        var closures = pipelineFactory()
+        if let framerFactory = framerFactory {
             closures = framerFactory().composing(closures)
         }
 
@@ -939,8 +939,8 @@ extension ServerBootstrap {
 
         let transport = TransportInfo(kind: .tcp, isStream: true)
         let endpoint = Endpoint.ipHost(hostname: "0.0.0.0", port: port)
-        var closures = _pipelineFactory()
-        if let framerFactory = _framerFactory {
+        var closures = pipelineFactory()
+        if let framerFactory = framerFactory {
             closures = framerFactory().composing(closures)
         }
 

--- a/Sources/WendyNet/Backend+WendyLite.swift
+++ b/Sources/WendyNet/Backend+WendyLite.swift
@@ -70,6 +70,40 @@ fileprivate final class _LockedBox<T>: @unchecked Sendable {
     }
 }
 
+// MARK: - Parked-waiter helper
+//
+// The single-parked-continuation pattern shared by the listener's accept loop
+// and the channel's receive loop: poll for a ready value under the state lock,
+// else park one continuation (a second concurrent caller is rejected via
+// `park`), with cancellation taking and resuming the parked waiter. External
+// events (host drain, close) resume the same waiter field directly.
+//
+//   poll:         ready value, or nil to park
+//   park:         store the continuation, or return a value (e.g. concurrentAccess)
+//   cancelWaiter: take and clear the parked continuation
+private func _parkOrResume<S, R: Sendable>(
+    _ box: _LockedBox<S>,
+    cancelled: R,
+    poll: @escaping @Sendable (inout S) -> R?,
+    park: @escaping @Sendable (inout S, CheckedContinuation<R, Never>) -> R?,
+    cancelWaiter: @escaping @Sendable (inout S) -> CheckedContinuation<R, Never>?
+) async -> R {
+    if let fast = box.withLockedValue({ poll(&$0) }) { return fast }
+    return await withTaskCancellationHandler(operation: {
+        await withCheckedContinuation { (continuation: CheckedContinuation<R, Never>) in
+            let now: R? = box.withLockedValue { s in
+                if Task.isCancelled { return cancelled }
+                if let r = poll(&s) { return r }
+                return park(&s, continuation)
+            }
+            if let now { continuation.resume(returning: now) }
+        }
+    }, onCancel: {
+        let waiter = box.withLockedValue { cancelWaiter(&$0) }
+        waiter?.resume(returning: cancelled)
+    })
+}
+
 private let wendyNetCallbackHandlerID: Int32 = 2
 private let wendyNetEventAcceptReady: Int32 = 1
 private let wendyNetEventReadReady: Int32 = 2
@@ -294,43 +328,26 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
         }
 
         drainAccepted()
-        let fast2: Result<Channel<Message>?, WendyNetError>? = state.withLockedValue { s in
-            if !s.pendingChannels.isEmpty { return .success(s.pendingChannels.removeFirst()) }
-            if s.isClosed { return .success(nil) }
-            return nil
-        }
-        if let fast2 {
-            switch fast2 {
-            case .success(let c): return c
-            case .failure(let e): throw e
-            }
-        }
 
-        let result = await withTaskCancellationHandler(operation: { [self] () async -> Result<Channel<Message>?, WendyNetError> in
-            await withCheckedContinuation { (continuation: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>) in
-                let resume: Result<Channel<Message>?, WendyNetError>? = state.withLockedValue { s in
-                    if Task.isCancelled { return .failure(.cancelled) }
-                    if !s.pendingChannels.isEmpty { return .success(s.pendingChannels.removeFirst()) }
-                    if s.isClosed { return .success(nil) }
-                    if s.acceptWaiter != nil {
-                        return .failure(.concurrentAccess)
-                    }
-                    s.acceptWaiter = continuation
-                    return nil
-                }
-                if let resume {
-                    continuation.resume(returning: resume)
-                }
+        let result = await _parkOrResume(
+            state,
+            cancelled: Result<Channel<Message>?, WendyNetError>.failure(.cancelled),
+            poll: { s in
+                if !s.pendingChannels.isEmpty { return .success(s.pendingChannels.removeFirst()) }
+                if s.isClosed { return .success(nil) }
+                return nil
+            },
+            park: { s, continuation in
+                if s.acceptWaiter != nil { return .failure(.concurrentAccess) }
+                s.acceptWaiter = continuation
+                return nil
+            },
+            cancelWaiter: { s in
+                let w = s.acceptWaiter
+                s.acceptWaiter = nil
+                return w
             }
-        }, onCancel: { [self] in
-            let waiter: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>? =
-                state.withLockedValue { s in
-                    let w = s.acceptWaiter
-                    s.acceptWaiter = nil
-                    return w
-                }
-            waiter?.resume(returning: .failure(.cancelled))
-        })
+        )
         switch result {
         case .success(let channel): return channel
         case .failure(let error): throw error
@@ -493,39 +510,27 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
             }
         }
         drainReadable()
-        if let early = tryDeliverReceived() {
-            switch early {
-            case .success(let m): return m
-            case .failure(let e): throw e
-            }
-        }
 
-        let result = await withTaskCancellationHandler(operation: { [self] () async -> Result<Message?, WendyNetError> in
-            await withCheckedContinuation { (continuation: CheckedContinuation<Result<Message?, WendyNetError>, Never>) in
-                let resumeNow: Result<Message?, WendyNetError>? = state.withLockedValue { s in
-                    if Task.isCancelled { return .failure(.cancelled) }
-                    if !s.decodedMessages.isEmpty { return .success(s.decodedMessages.removeFirst()) }
-                    if let err = s.error { return .failure(err) }
-                    if s.closed { return .success(nil) }
-                    if s.receiveWaiter != nil {
-                        return .failure(.concurrentAccess)
-                    }
-                    s.receiveWaiter = continuation
-                    return nil
-                }
-                if let resumeNow {
-                    continuation.resume(returning: resumeNow)
-                }
+        let result = await _parkOrResume(
+            state,
+            cancelled: Result<Message?, WendyNetError>.failure(.cancelled),
+            poll: { s in
+                if !s.decodedMessages.isEmpty { return .success(s.decodedMessages.removeFirst()) }
+                if let err = s.error { return .failure(err) }
+                if s.closed { return .success(nil) }
+                return nil
+            },
+            park: { s, continuation in
+                if s.receiveWaiter != nil { return .failure(.concurrentAccess) }
+                s.receiveWaiter = continuation
+                return nil
+            },
+            cancelWaiter: { s in
+                let w = s.receiveWaiter
+                s.receiveWaiter = nil
+                return w
             }
-        }, onCancel: { [self] in
-            let waiter: CheckedContinuation<Result<Message?, WendyNetError>, Never>? =
-                state.withLockedValue { s in
-                    let w = s.receiveWaiter
-                    s.receiveWaiter = nil
-                    return w
-                }
-            waiter?.resume(returning: .failure(.cancelled))
-        })
+        )
         switch result {
         case .success(let message): return message
         case .failure(let error): throw error

--- a/Sources/WendyNet/Backend+WendyLite.swift
+++ b/Sources/WendyNet/Backend+WendyLite.swift
@@ -546,7 +546,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         }
     }
 
-    private func send(_ message: Message) async throws(WendyNetError) -> SendResult {
+    private func send(_ message: Message) async throws(WendyNetError) {
         // Initial gating: error / closed / cancelled.
         let earlyError: WendyNetError? = state.withLockedValue { s in
             if let err = s.error { return err }
@@ -563,7 +563,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
 
         // Cancellation: close the channel so any in-flight syscall observes EBADF
         // and the parked writable waiter wakes via closeWithError.
-        let result = await withTaskCancellationHandler(operation: { [self] () async -> Result<SendResult, WendyNetError> in
+        let result = await withTaskCancellationHandler(operation: { [self] () async -> Result<Void, WendyNetError> in
             var offset = 0
             let total = buffer.readableBytes
             while offset < total {
@@ -594,7 +594,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 }
                 if written == 0 {
                     await waitForWritable()
-                    let post: Result<SendResult, WendyNetError>? = state.withLockedValue { s in
+                    let post: Result<Void, WendyNetError>? = state.withLockedValue { s in
                         if let err = s.error { return .failure(err) }
                         if s.closed { return .failure(.closed) }
                         return nil
@@ -606,7 +606,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 let resolved: WendyNetError = state.withLockedValue { s in s.error ?? .closed }
                 return .failure(resolved)
             }
-            return .success(.accepted)
+            return .success(())
         }, onCancel: { [self] in
             let shouldClose: Bool = state.withLockedValue { s in !s.closed && s.error == nil }
             if shouldClose {
@@ -614,7 +614,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
             }
         })
         switch result {
-        case .success(let r): return r
+        case .success: return
         case .failure(let err): throw err
         }
     }
@@ -647,8 +647,8 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         })
         let outbound = Outbound<Message>(writeStep: { [self] msg in
             do throws(WendyNetError) {
-                let result = try await send(msg)
-                return .accepted(result)
+                try await send(msg)
+                return .accepted
             } catch {
                 return .failure(error)
             }

--- a/Sources/WendyNet/Internal.swift
+++ b/Sources/WendyNet/Internal.swift
@@ -1,0 +1,126 @@
+// Non-public plumbing shared by both backends. API.swift carries the public
+// surface; everything internal-only lives here.
+
+let wendyNetMaximumMessageLength = 1024
+
+// MARK: - Internal step results
+
+enum InboundStep<Message: Sendable>: Sendable {
+    case message(Message)
+    case end
+    case failure(WendyNetError)
+}
+
+enum OutboundStep: Sendable {
+    case accepted
+    case failure(WendyNetError)
+}
+
+enum AcceptedStep<Message: Sendable>: Sendable {
+    case channel(Channel<Message>)
+    case end
+    case failure(WendyNetError)
+}
+
+// MARK: - Pipeline closures
+
+/// Closure bundle produced by a pipeline factory.
+struct PipelineClosures<Message> {
+    let decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
+    let encode: (Message) -> ByteBuffer
+    let started: (ConnectionContext) -> Void
+}
+
+/// Closure bundle for a framer (ByteBuffer -> ByteBuffer, stream transports only).
+struct FramerClosures {
+    let decode: (ByteBuffer, (ByteBuffer) -> Void, (WendyNetError) -> Void) -> Void
+    let encode: (ByteBuffer) -> ByteBuffer
+    let started: (ConnectionContext) -> Void
+
+    /// Wrap a pipeline's closures so the framer runs first on inbound
+    /// and last on outbound.
+    func composing<Message>(_ inner: PipelineClosures<Message>) -> PipelineClosures<Message> {
+        let framerDecode = self.decode
+        let framerEncode = self.encode
+        let framerStarted = self.started
+        return PipelineClosures<Message>(
+            decode: { buf, emit, fail in
+                framerDecode(buf, { frameBuf in
+                    inner.decode(frameBuf, emit, fail)
+                }, fail)
+            },
+            encode: { msg in
+                framerEncode(inner.encode(msg))
+            },
+            started: { context in
+                framerStarted(context)
+                inner.started(context)
+            }
+        )
+    }
+}
+
+// MARK: - Bootstrap configuration
+
+/// Shared configuration backing both `ClientBootstrap` and `ServerBootstrap`.
+struct BootstrapConfig<Message: Sendable>: Sendable {
+    var security: SecurityMode = .insecure
+    var udpAssociationTimeoutSeconds: Int = 60
+    let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    var framerFactory: (@Sendable () -> FramerClosures)? = nil
+
+    /// The identity pipeline: raw bytes through, no decode/encode transform.
+    static func passthrough() -> BootstrapConfig<ByteBuffer> {
+        BootstrapConfig<ByteBuffer>(
+            pipelineFactory: {
+                PipelineClosures(
+                    decode: { buf, emit, _ in emit(buf) },
+                    encode: { $0 },
+                    started: { _ in }
+                )
+            }
+        )
+    }
+
+    /// Re-key this config to a new message type, swapping in a fresh pipeline
+    /// factory while preserving every other field (so `.pipeline()` can't drop
+    /// a previously configured option).
+    func reframed<New: Sendable>(
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<New>
+    ) -> BootstrapConfig<New> {
+        BootstrapConfig<New>(
+            security: security,
+            udpAssociationTimeoutSeconds: udpAssociationTimeoutSeconds,
+            pipelineFactory: pipelineFactory,
+            framerFactory: framerFactory
+        )
+    }
+}
+
+/// Wrap a `PipelineStage` factory into framer closures.
+func makeFramerClosures<F: PipelineStage & SendableMetatype>(
+    _ factory: @escaping @Sendable () -> F
+) -> @Sendable () -> FramerClosures where F.Input == ByteBuffer, F.Output == ByteBuffer {
+    {
+        let framer = factory()
+        return FramerClosures(
+            decode: { buf, emit, fail in framer.decode(buf, emit, fail) },
+            encode: { buf in framer.encode(buf) },
+            started: { context in framer.started(context: context) }
+        )
+    }
+}
+
+/// Wrap a `PipelineStage` factory into pipeline closures.
+func makePipelineClosures<P: PipelineStage & SendableMetatype>(
+    _ build: @escaping @Sendable () -> P
+) -> @Sendable () -> PipelineClosures<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
+    {
+        let pipeline = build()
+        return PipelineClosures(
+            decode: { buf, emit, fail in pipeline.decode(buf, emit, fail) },
+            encode: { msg in pipeline.encode(msg) },
+            started: { context in pipeline.started(context: context) }
+        )
+    }
+}


### PR DESCRIPTION
Mostly internal changes tightening up the code so that the addition of UDP client/server support can be a more focused change in a subsequent PR.

* (Public API) Remove `SendResult` return type since we cannot accurately inform the developer whether their unreliable payload was sent or dropped. We could tell them if _we_ dropped it (via active queue management) but not if the OS does, or one of the routers. It's not a dependable signal so better to leave it out.
* (Unused public API) Drop unnecessary `tls` argument name for `SecurityMode`'s `TLSOptions`
* Factor out duplicate bootstrap configuration between client/server
* Factor out duplicate async machinery, especially that which will be reused by UDP
* Stop using prefixed underscores and rely fully on Swift access control for public vs internal variables and types
* Keep the public `API.swift` clean by moving internal helpers to a new `Internal.swift` file

Aside from the minor API changes there shouldn't be any functional differences.