### PR TITLE
WendyNet: UDP datagram support

### DIFF
--- a/Sources/CWendyNet/include/wendynet.h
+++ b/Sources/CWendyNet/include/wendynet.h
@@ -1,7 +1,7 @@
 #ifndef CWENDYNET_H
 #define CWENDYNET_H
 
-/* WendyNet async TCP host imports.
+/* WendyNet async TCP/UDP host imports.
  *
  * Imports under module "wendy" are merged at link time with declarations
  * from CWendyLite (and any other host-import target) into a single WASM
@@ -30,6 +30,12 @@ int wendynet_tcp_listen(int port, int backlog);
 
 __attribute__((import_module("wendy"), import_name("wendynet_tcp_connect")))
 int wendynet_tcp_connect(const char *host, int host_len, int port);
+
+__attribute__((import_module("wendy"), import_name("wendynet_udp_listen")))
+int wendynet_udp_listen(int port);
+
+__attribute__((import_module("wendy"), import_name("wendynet_udp_connect")))
+int wendynet_udp_connect(const char *host, int host_len, int port);
 
 __attribute__((import_module("wendy"), import_name("wendynet_listener_accept")))
 int wendynet_listener_accept(int listener_handle);

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -336,6 +336,11 @@ public struct Outbound<Message: Sendable>: Sendable {
 /// This is a unicast iterator: only one consumer at a time. Invoking `next()`
 /// from a concurrent context that contends with another such call throws
 /// `WendyNetError.concurrentAccess`.
+///
+/// Each accepted channel must be driven with `executeThenClose`; that scope is
+/// what releases the connection (and, for a UDP listener, the per-peer
+/// association and its idle timer). Accepting a channel and dropping it without
+/// running `executeThenClose` holds those resources until the listener closes.
 public struct Accepted<Message: Sendable>: Sendable {
     let nextStep: @Sendable () async -> AcceptedStep<Message>
 
@@ -436,6 +441,23 @@ public enum TransportKind: Sendable {
     case bluetoothL2CAP
 }
 
+// MARK: - Reliability
+
+/// Whether the application requires reliable, in-order delivery.
+///
+/// `.reliable` selects a stream transport (TCP today): bytes arrive in order
+/// and without loss, and any configured framer is applied.
+///
+/// `.unreliable` selects a datagram transport (UDP today): each `write` maps to
+/// one datagram, which may be dropped or reordered in transit. A successful
+/// `write` only means the datagram was handed to the transport; there is no
+/// per-write delivery signal. Framers are not applied; datagrams already carry
+/// their own message boundaries.
+public enum Reliability: Sendable {
+    case reliable
+    case unreliable
+}
+
 // MARK: - Peer Info
 
 public struct PeerInfo: Sendable {
@@ -533,7 +555,7 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
 
     // Accessors used by the backend `connect(to:)` extensions.
     var security: SecurityMode { config.security }
-    var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
+    var reliability: Reliability { config.reliability }
     var pipelineFactory: @Sendable () -> PipelineClosures<Message> { config.pipelineFactory }
     var framerFactory: (@Sendable () -> FramerClosures)? { config.framerFactory }
 
@@ -554,9 +576,10 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
         return copy
     }
 
-    public func udpAssociationTimeout(seconds: Int) -> ClientBootstrap {
+    /// Select reliable or unreliable transport.
+    public func reliability(_ mode: Reliability) -> ClientBootstrap {
         var copy = self
-        copy.config.udpAssociationTimeoutSeconds = seconds
+        copy.config.reliability = mode
         return copy
     }
 
@@ -590,10 +613,13 @@ public struct ClientBootstrap<Message: Sendable>: Sendable {
 public struct ServerBootstrap<Message: Sendable>: Sendable {
     let wendyNet: WendyNet
     var config: BootstrapConfig<Message>
+    /// Idle timeout for per-peer UDP associations. Server-only: each source
+    /// address is a separate association, unlike a client's single peer.
+    var udpAssociationTimeout: Duration = .seconds(60)
 
     // Accessors used by the backend `bind(port:)` extensions.
     var security: SecurityMode { config.security }
-    var udpAssociationTimeoutSeconds: Int { config.udpAssociationTimeoutSeconds }
+    var reliability: Reliability { config.reliability }
     var pipelineFactory: @Sendable () -> PipelineClosures<Message> { config.pipelineFactory }
     var framerFactory: (@Sendable () -> FramerClosures)? { config.framerFactory }
 
@@ -602,9 +628,14 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
         self.config = .passthrough()
     }
 
-    init(wendyNet: WendyNet, config: BootstrapConfig<Message>) {
+    init(
+        wendyNet: WendyNet,
+        config: BootstrapConfig<Message>,
+        udpAssociationTimeout: Duration = .seconds(60)
+    ) {
         self.wendyNet = wendyNet
         self.config = config
+        self.udpAssociationTimeout = udpAssociationTimeout
     }
 
     public func security(_ mode: SecurityMode) -> ServerBootstrap {
@@ -613,9 +644,20 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
         return copy
     }
 
-    public func udpAssociationTimeout(seconds: Int) -> ServerBootstrap {
+    /// Select reliable or unreliable transport.
+    public func reliability(_ mode: Reliability) -> ServerBootstrap {
         var copy = self
-        copy.config.udpAssociationTimeoutSeconds = seconds
+        copy.config.reliability = mode
+        return copy
+    }
+
+    /// Idle timeout for per-peer UDP associations on a datagram listener. Each
+    /// distinct source address is a separate association; one that goes idle
+    /// for longer than this is closed (its accepted channel sees end-of-stream)
+    /// and its resources reclaimed. Ignored for stream transports.
+    public func udpAssociationTimeout(_ timeout: Duration) -> ServerBootstrap {
+        var copy = self
+        copy.udpAssociationTimeout = timeout
         return copy
     }
 
@@ -635,7 +677,8 @@ public struct ServerBootstrap<Message: Sendable>: Sendable {
     ) -> ServerBootstrap<P.Output> where P.Input == ByteBuffer, P.Output: Sendable {
         ServerBootstrap<P.Output>(
             wendyNet: wendyNet,
-            config: config.reframed(pipelineFactory: makePipelineClosures(build))
+            config: config.reframed(pipelineFactory: makePipelineClosures(build)),
+            udpAssociationTimeout: udpAssociationTimeout
         )
     }
 }

--- a/Sources/WendyNet/API.swift
+++ b/Sources/WendyNet/API.swift
@@ -435,7 +435,7 @@ public struct TransportInfo: Sendable {
     }
 }
 
-public enum TransportKind: Sendable {
+@nonexhaustive public enum TransportKind: Sendable {
     case tcp
     case udp
     case bluetoothL2CAP
@@ -453,7 +453,7 @@ public enum TransportKind: Sendable {
 /// `write` only means the datagram was handed to the transport; there is no
 /// per-write delivery signal. Framers are not applied; datagrams already carry
 /// their own message boundaries.
-public enum Reliability: Sendable {
+@nonexhaustive public enum Reliability: Sendable {
     case reliable
     case unreliable
 }
@@ -707,7 +707,7 @@ public final class WendyNet: Sendable {
 
 // MARK: - Discovery
 
-public enum DiscoveryEvent: Sendable {
+@nonexhaustive public enum DiscoveryEvent: Sendable {
     case peerDiscovered(DiscoveredPeer)
     case peerLost(DiscoveredPeer)
 }
@@ -722,7 +722,7 @@ public struct DiscoveryStream: Sendable {
 
 // MARK: - Errors
 
-public enum WendyNetError: Error, Sendable {
+@nonexhaustive public enum WendyNetError: Error, Sendable {
     case discoveryError
     case listenerError
     case connectionFailed
@@ -746,7 +746,7 @@ public enum WendyNetError: Error, Sendable {
 
 // MARK: - Endpoint
 
-public enum Endpoint: Sendable {
+@nonexhaustive public enum Endpoint: Sendable {
     case wendyPeer(publicKey: String, port: UInt16)
     case ipHost(hostname: String, port: UInt16)
 
@@ -797,7 +797,7 @@ public struct DiscoveryOptions: Sendable {
 
 // MARK: - Security
 
-public enum SecurityMode: Sendable {
+@nonexhaustive public enum SecurityMode: Sendable {
     case wendyPeer
     case insecure
     case tls(TLSOptions)
@@ -812,7 +812,7 @@ public struct TLSOptions: Sendable {
     public init() {}
 }
 
-public enum CertificateRoots: Sendable {
+@nonexhaustive public enum CertificateRoots: Sendable {
     case system
     case webPKI
     case custom([String])

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -492,7 +492,6 @@ fileprivate final class UDPDemuxHub<Message: Sendable>: Sendable {
             security: context.security
         )
         let closures = pipelineFactory()
-        closures.started(peerContext)
 
         let core = ChannelCore<Message>(
             udpConduit: conduit,
@@ -521,6 +520,7 @@ fileprivate final class UDPDemuxHub<Message: Sendable>: Sendable {
                 return (nil, false)
             }
         if dropped { return }
+        closures.started(peerContext)
         conduit.deliver(envelope.data)
         waiter?.resume(returning: .channel(channel))
     }
@@ -978,7 +978,6 @@ extension ClientBootstrap {
         }
 
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
-        closures.started(context)
 
         let nioAsyncChannel: NIOByteBufferChannel
         do {
@@ -1007,6 +1006,8 @@ extension ClientBootstrap {
         } catch {
             throw .connectionFailed
         }
+
+        closures.started(context)
 
         let core = ChannelCore<Message>(
             nioAsyncChannel: nioAsyncChannel,

--- a/Sources/WendyNet/Backend+Standard.swift
+++ b/Sources/WendyNet/Backend+Standard.swift
@@ -34,10 +34,56 @@ fileprivate final class LockedBox<T>: @unchecked Sendable {
     }
 }
 
+// MARK: - Parked-waiter helper
+//
+// The single-parked-continuation pattern shared by the conduit reader and the
+// hub's accept iterator: poll for a ready value under the state lock, else park
+// one continuation (a second concurrent caller is rejected via `park`), with
+// cancellation taking and resuming the parked waiter.
+//
+//   poll:         ready value, or nil to park
+//   park:         store the continuation, or return a value (e.g. concurrentAccess)
+//   cancelWaiter: take and clear the parked continuation
+private func parkOrResume<S, R: Sendable>(
+    _ box: LockedBox<S>,
+    cancelled: R,
+    poll: @escaping @Sendable (inout S) -> R?,
+    park: @escaping @Sendable (inout S, CheckedContinuation<R, Never>) -> R?,
+    cancelWaiter: @escaping @Sendable (inout S) -> CheckedContinuation<R, Never>?
+) async -> R {
+    if let fast = box.withLockedValue({ poll(&$0) }) { return fast }
+    return await withTaskCancellationHandler(operation: {
+        await withCheckedContinuation { (continuation: CheckedContinuation<R, Never>) in
+            let now: R? = box.withLockedValue { s in
+                if Task.isCancelled { return cancelled }
+                if let r = poll(&s) { return r }
+                return park(&s, continuation)
+            }
+            if let now { continuation.resume(returning: now) }
+        }
+    }, onCancel: {
+        let waiter = box.withLockedValue { cancelWaiter(&$0) }
+        waiter?.resume(returning: cancelled)
+    })
+}
+
 private let standardEventLoopGroup = MultiThreadedEventLoopGroup.singleton
 
 fileprivate typealias NIOByteBufferChannel = NIOAsyncChannel<ByteBuffer, ByteBuffer>
 fileprivate typealias NIOServerInboundChannel = NIOAsyncChannel<NIOByteBufferChannel, Never>
+fileprivate typealias NIODatagramChannel = NIOAsyncChannel<AddressedEnvelope<ByteBuffer>, AddressedEnvelope<ByteBuffer>>
+
+// MARK: - Connected-UDP unwrap handler
+
+private final class DatagramUnwrapHandler: ChannelInboundHandler {
+    typealias InboundIn = AddressedEnvelope<ByteBuffer>
+    typealias InboundOut = ByteBuffer
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let envelope = unwrapInboundIn(data)
+        context.fireChannelRead(wrapInboundOut(envelope.data))
+    }
+}
 
 // MARK: - Inbound / outbound bridges
 
@@ -254,6 +300,291 @@ private final class AcceptIteratorBox<Message: Sendable>: Sendable {
     }
 }
 
+// MARK: - UDP peer conduit
+//
+// A per-peer association on a shared (unconnected) datagram listener. The
+// listener's demux pump routes each inbound datagram to the conduit matching
+// its source address; writes go back out through the shared channel's writer
+// wrapped in an `AddressedEnvelope` carrying this conduit's remote address.
+
+fileprivate final class UDPPeerConduit: Sendable {
+    let remote: SocketAddress
+    private let writer: NIOAsyncChannelOutboundWriter<AddressedEnvelope<ByteBuffer>>
+    /// Removes this association from the hub's demux map, so a later datagram
+    /// from the same source spawns a fresh accepted channel.
+    private let onClose: @Sendable (SocketAddress) -> Void
+
+    private struct State {
+        var pending: [ByteBuffer] = []
+        // Briefly holds the (single) parked reader. A second concurrent
+        // `next()` observing a non-nil waiter gets `.concurrentAccess`.
+        var waiter: CheckedContinuation<Result<ByteBuffer?, WendyNetError>, Never>? = nil
+        var ended = false
+        var error: WendyNetError? = nil
+        var lastActivity: ContinuousClock.Instant
+    }
+    private let state: LockedBox<State>
+
+    init(
+        remote: SocketAddress,
+        writer: NIOAsyncChannelOutboundWriter<AddressedEnvelope<ByteBuffer>>,
+        onClose: @escaping @Sendable (SocketAddress) -> Void
+    ) {
+        self.remote = remote
+        self.writer = writer
+        self.onClose = onClose
+        self.state = LockedBox(State(lastActivity: ContinuousClock().now))
+    }
+
+    /// Time left before the idle deadline (`timeout` since the last datagram):
+    /// `nil` once the association has ended, `<= .zero` once it has expired.
+    func idleRemaining(timeout: Duration) -> Duration? {
+        state.withLockedValue { s in
+            s.ended ? nil : timeout - (ContinuousClock().now - s.lastActivity)
+        }
+    }
+
+    /// Called by the demux pump when a datagram arrives from `remote`.
+    func deliver(_ buf: ByteBuffer) {
+        let waiter: CheckedContinuation<Result<ByteBuffer?, WendyNetError>, Never>? =
+            state.withLockedValue { s in
+                if s.ended { return nil }  // association torn down: drop (UDP semantics)
+                s.lastActivity = ContinuousClock().now
+                if let w = s.waiter {
+                    s.waiter = nil
+                    return w
+                }
+                s.pending.append(buf)
+                return nil
+            }
+        waiter?.resume(returning: .success(buf))
+    }
+
+    /// Terminal: the listener went away or the channel scope exited. Buffered
+    /// datagrams already decoded upstream stay deliverable; the next read here
+    /// observes end-of-stream (or `error`).
+    func finish(_ error: WendyNetError?) {
+        let waiter: CheckedContinuation<Result<ByteBuffer?, WendyNetError>, Never>? =
+            state.withLockedValue { s in
+                if s.ended { return nil }
+                s.ended = true
+                s.error = error
+                let w = s.waiter
+                s.waiter = nil
+                return w
+            }
+        if let waiter {
+            if let error {
+                waiter.resume(returning: .failure(error))
+            } else {
+                waiter.resume(returning: .success(nil))
+            }
+        }
+    }
+
+    func next() async -> Result<ByteBuffer?, WendyNetError> {
+        await parkOrResume(
+            state,
+            cancelled: Result<ByteBuffer?, WendyNetError>.failure(.cancelled),
+            poll: { s in
+                if !s.pending.isEmpty { return .success(s.pending.removeFirst()) }
+                if let err = s.error { return .failure(err) }
+                if s.ended { return .success(nil) }
+                return nil
+            },
+            park: { s, continuation in
+                if s.waiter != nil { return .failure(.concurrentAccess) }
+                s.waiter = continuation
+                return nil
+            },
+            cancelWaiter: { s in
+                let w = s.waiter
+                s.waiter = nil
+                return w
+            }
+        )
+    }
+
+    func write(_ buf: ByteBuffer) async -> OutboundStep {
+        let earlyError: WendyNetError? = state.withLockedValue { s in
+            if let err = s.error { return err }
+            if s.ended { return .closed }
+            s.lastActivity = ContinuousClock().now
+            return nil
+        }
+        if let earlyError { return .failure(earlyError) }
+        do {
+            try await writer.write(AddressedEnvelope(remoteAddress: remote, data: buf))
+        } catch is CancellationError {
+            return .failure(.cancelled)
+        } catch {
+            return .failure(.connectionFailed)
+        }
+        return .accepted
+    }
+
+    /// Channel scope exited: end the association and unhook from the demux map.
+    func close() {
+        finish(nil)
+        onClose(remote)
+    }
+}
+
+// MARK: - UDP demux hub
+//
+// Owns the per-source-address association map for one bound (unconnected)
+// datagram listener. The first datagram from a new source spawns a
+// `UDPPeerConduit` plus an accepted `Channel`; subsequent datagrams route to
+// the existing conduit. Datagrams arriving after the hub has finished are
+// dropped (acceptable UDP semantics).
+
+fileprivate final class UDPDemuxHub<Message: Sendable>: Sendable {
+    private struct State {
+        var peers: [SocketAddress: UDPPeerConduit] = [:]
+        var pendingChannels: [Channel<Message>] = []
+        // Briefly holds the (single) parked accept() caller. A second
+        // concurrent caller observing non-nil gets `.concurrentAccess`.
+        var acceptWaiter: CheckedContinuation<AcceptedStep<Message>, Never>? = nil
+        var ended = false
+        var error: WendyNetError? = nil
+    }
+    private let state: LockedBox<State>
+    private let context: ConnectionContext
+    private let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    private let writer: NIOAsyncChannelOutboundWriter<AddressedEnvelope<ByteBuffer>>
+    /// Idle timeout applied to each accepted association (`.zero` disables).
+    private let idleTimeout: Duration
+
+    init(
+        context: ConnectionContext,
+        idleTimeout: Duration,
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<Message>,
+        writer: NIOAsyncChannelOutboundWriter<AddressedEnvelope<ByteBuffer>>
+    ) {
+        self.state = LockedBox(State())
+        self.context = context
+        self.idleTimeout = idleTimeout
+        self.pipelineFactory = pipelineFactory
+        self.writer = writer
+    }
+
+    /// Called only from the (single) demux pump task, so creation of a new
+    /// association cannot race with itself.
+    func deliver(_ envelope: AddressedEnvelope<ByteBuffer>) {
+        let remote = envelope.remoteAddress
+
+        let existing: UDPPeerConduit? = state.withLockedValue { s in s.peers[remote] }
+        if let existing {
+            existing.deliver(envelope.data)
+            return
+        }
+
+        // New peer: spawn a conduit and an accepted channel around it. The
+        // pipeline closures are constructed here -- once per association --
+        // and immediately confined to the channel core's locked storage.
+        let conduit = UDPPeerConduit(remote: remote, writer: writer, onClose: { [weak self] r in
+            self?.removePeer(r)
+        })
+        let endpoint = Self.endpoint(for: remote)
+        let peerContext = ConnectionContext(
+            remoteEndpoint: endpoint,
+            transport: context.transport,
+            security: context.security
+        )
+        let closures = pipelineFactory()
+        closures.started(peerContext)
+
+        let core = ChannelCore<Message>(
+            udpConduit: conduit,
+            idleTimeout: idleTimeout,
+            endpoint: endpoint,
+            transport: context.transport,
+            decode: closures.decode,
+            encode: closures.encode
+        )
+        let channel = Channel<Message>(
+            endpoint: endpoint,
+            transport: context.transport,
+            maximumMessageLength: wendyNetMaximumMessageLength,
+            core: core
+        )
+
+        let (waiter, dropped): (CheckedContinuation<AcceptedStep<Message>, Never>?, Bool) =
+            state.withLockedValue { s in
+                if s.ended { return (nil, true) }
+                s.peers[remote] = conduit
+                if let w = s.acceptWaiter {
+                    s.acceptWaiter = nil
+                    return (w, false)
+                }
+                s.pendingChannels.append(channel)
+                return (nil, false)
+            }
+        if dropped { return }
+        conduit.deliver(envelope.data)
+        waiter?.resume(returning: .channel(channel))
+    }
+
+    func nextAccepted() async -> AcceptedStep<Message> {
+        await parkOrResume(
+            state,
+            cancelled: AcceptedStep<Message>.failure(.cancelled),
+            poll: { s in
+                if !s.pendingChannels.isEmpty { return .channel(s.pendingChannels.removeFirst()) }
+                if let err = s.error { return .failure(err) }
+                if s.ended { return .end }
+                return nil
+            },
+            park: { s, continuation in
+                if s.acceptWaiter != nil { return .failure(.concurrentAccess) }
+                s.acceptWaiter = continuation
+                return nil
+            },
+            cancelWaiter: { s in
+                let w = s.acceptWaiter
+                s.acceptWaiter = nil
+                return w
+            }
+        )
+    }
+
+    /// Terminal: the listener scope is unwinding (or the pump hit an error).
+    /// First call wins; ends every live association.
+    func finish(_ error: WendyNetError?) {
+        let (waiter, conduits): (CheckedContinuation<AcceptedStep<Message>, Never>?, [UDPPeerConduit]) =
+            state.withLockedValue { s in
+                if s.ended { return (nil, []) }
+                s.ended = true
+                s.error = error
+                let w = s.acceptWaiter
+                s.acceptWaiter = nil
+                let cs = Array(s.peers.values)
+                s.peers.removeAll()
+                return (w, cs)
+            }
+        if let waiter {
+            if let error {
+                waiter.resume(returning: .failure(error))
+            } else {
+                waiter.resume(returning: .end)
+            }
+        }
+        for conduit in conduits {
+            conduit.finish(error)
+        }
+    }
+
+    private func removePeer(_ remote: SocketAddress) {
+        state.withLockedValue { s in
+            _ = s.peers.removeValue(forKey: remote)
+        }
+    }
+
+    private static func endpoint(for address: SocketAddress) -> Endpoint {
+        .ipHost(hostname: address.ipAddress ?? "?", port: UInt16(address.port ?? 0))
+    }
+}
+
 // MARK: - ChannelCore
 //
 // Sendable. The non-Sendable pipeline closures live inside `LockedBox<Closures?>`
@@ -264,10 +595,18 @@ private final class AcceptIteratorBox<Message: Sendable>: Sendable {
 // bridges. The atomic check-and-clear inside `withLockedValue` makes that
 // race impossible -- exactly one caller wins.
 
+fileprivate enum ChannelBacking {
+    /// TCP connection or connected-UDP client: a dedicated NIO channel.
+    case nio(NIOByteBufferChannel)
+    /// Per-peer association on a shared datagram listener, with its idle
+    /// timeout (`.zero` disables idle reaping).
+    case udpPeer(UDPPeerConduit, idleTimeout: Duration)
+}
+
 final class ChannelCore<Message: Sendable>: Sendable {
     let endpoint: Endpoint
     let transport: TransportInfo
-    fileprivate let nioAsyncChannel: NIOByteBufferChannel
+    private let backing: ChannelBacking
     private struct Closures {
         let decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
         let encode: (Message) -> ByteBuffer
@@ -281,7 +620,21 @@ final class ChannelCore<Message: Sendable>: Sendable {
         decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
         encode: @escaping (Message) -> ByteBuffer
     ) {
-        self.nioAsyncChannel = nioAsyncChannel
+        self.backing = .nio(nioAsyncChannel)
+        self.endpoint = endpoint
+        self.transport = transport
+        self.closures = LockedBox(Closures(decode: decode, encode: encode))
+    }
+
+    fileprivate init(
+        udpConduit: UDPPeerConduit,
+        idleTimeout: Duration,
+        endpoint: Endpoint,
+        transport: TransportInfo,
+        decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
+        encode: @escaping (Message) -> ByteBuffer
+    ) {
+        self.backing = .udpPeer(udpConduit, idleTimeout: idleTimeout)
         self.endpoint = endpoint
         self.transport = transport
         self.closures = LockedBox(Closures(decode: decode, encode: encode))
@@ -304,6 +657,31 @@ final class ChannelCore<Message: Sendable>: Sendable {
         let decodeClosure = taken.decode
         let encodeClosure = taken.encode
 
+        switch backing {
+        case .nio(let nioAsyncChannel):
+            return try await executeThenCloseNIO(
+                nioAsyncChannel,
+                decode: decodeClosure,
+                encode: encodeClosure,
+                body
+            )
+        case .udpPeer(let conduit, let idleTimeout):
+            return try await executeThenCloseUDPPeer(
+                conduit,
+                idleTimeout: idleTimeout,
+                decode: decodeClosure,
+                encode: encodeClosure,
+                body
+            )
+        }
+    }
+
+    private func executeThenCloseNIO<R: Sendable>(
+        _ nioAsyncChannel: NIOByteBufferChannel,
+        decode decodeClosure: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
+        encode encodeClosure: @escaping (Message) -> ByteBuffer,
+        _ body: @Sendable (Inbound<Message>, Outbound<Message>) async throws(WendyNetError) -> R
+    ) async throws(WendyNetError) -> R {
         let outcome: Result<R, WendyNetError>
         do {
             outcome = try await nioAsyncChannel.executeThenClose { nioInbound, nioOutbound -> Result<R, WendyNetError> in
@@ -350,15 +728,79 @@ final class ChannelCore<Message: Sendable>: Sendable {
         case .failure(let e): throw e
         }
     }
+
+    private func executeThenCloseUDPPeer<R: Sendable>(
+        _ conduit: UDPPeerConduit,
+        idleTimeout: Duration,
+        decode decodeClosure: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
+        encode encodeClosure: @escaping (Message) -> ByteBuffer,
+        _ body: @Sendable (Inbound<Message>, Outbound<Message>) async throws(WendyNetError) -> R
+    ) async throws(WendyNetError) -> R {
+        let inboundBridge = InboundBridge<Message>(
+            decode: decodeClosure,
+            // Single-consumer contract is enforced by the conduit itself.
+            pull: { [conduit] in await conduit.next() }
+        )
+        let outboundBridge = OutboundBridge<Message>(
+            encode: encodeClosure,
+            sink: { [conduit] buf in await conduit.write(buf) }
+        )
+
+        let inbound = Inbound<Message>(nextStep: { [inboundBridge] in
+            await inboundBridge.next()
+        })
+        let outbound = Outbound<Message>(writeStep: { [outboundBridge] msg in
+            await outboundBridge.write(msg)
+        })
+
+        // Run the body alongside the association's idle timer; cancelling the
+        // group when the body returns tears the timer down with the channel.
+        // If the timer fires first it ends the conduit, surfacing end-of-stream
+        // to the body.
+        let outcome: Result<R, WendyNetError> =
+            await withTaskGroup(of: Void.self, returning: Result<R, WendyNetError>.self) { group in
+                if idleTimeout > .zero {
+                    group.addTask { [conduit] in
+                        await runIdleTimer(
+                            remaining: { conduit.idleRemaining(timeout: idleTimeout) },
+                            sleep: { d in (try? await Task.sleep(for: d)) != nil },
+                            evict: { conduit.close() }
+                        )
+                    }
+                }
+                let result: Result<R, WendyNetError>
+                do throws(WendyNetError) {
+                    result = .success(try await body(inbound, outbound))
+                } catch {
+                    result = .failure(error)
+                }
+                conduit.close()
+                group.cancelAll()
+                return result
+            }
+        switch outcome {
+        case .success(let v): return v
+        case .failure(let e): throw e
+        }
+    }
 }
 
 // MARK: - ListenerCore
 
 
+fileprivate enum ListenerBacking {
+    /// TCP: a NIO server channel yielding one child channel per connection.
+    case tcp(NIOServerInboundChannel)
+    /// UDP: a single bound datagram channel; associations are demultiplexed
+    /// by source address via `UDPDemuxHub`.
+    case udp(NIODatagramChannel)
+}
+
 final class ListenerCore<Message: Sendable>: Sendable {
     let port: UInt16
     let context: ConnectionContext
-    fileprivate let serverChannel: NIOServerInboundChannel
+    private let backing: ListenerBacking
+    private let udpAssociationTimeout: Duration
     private let pipelineFactory: @Sendable () -> PipelineClosures<Message>
     private let framerFactory: (@Sendable () -> FramerClosures)?
     /// Single-use latch -- see `executeThenClose` for rationale.
@@ -367,13 +809,15 @@ final class ListenerCore<Message: Sendable>: Sendable {
     fileprivate init(
         port: UInt16,
         context: ConnectionContext,
-        serverChannel: NIOServerInboundChannel,
+        backing: ListenerBacking,
+        udpAssociationTimeout: Duration,
         pipelineFactory: @escaping @Sendable () -> PipelineClosures<Message>,
         framerFactory: (@Sendable () -> FramerClosures)?
     ) {
         self.port = port
         self.context = context
-        self.serverChannel = serverChannel
+        self.backing = backing
+        self.udpAssociationTimeout = udpAssociationTimeout
         self.pipelineFactory = pipelineFactory
         self.framerFactory = framerFactory
     }
@@ -394,6 +838,18 @@ final class ListenerCore<Message: Sendable>: Sendable {
             throw .alreadyConsumed
         }
 
+        switch backing {
+        case .tcp(let serverChannel):
+            return try await executeThenCloseTCP(serverChannel, body)
+        case .udp(let datagramChannel):
+            return try await executeThenCloseUDP(datagramChannel, body)
+        }
+    }
+
+    private func executeThenCloseTCP<R: Sendable>(
+        _ serverChannel: NIOServerInboundChannel,
+        _ body: @Sendable (Accepted<Message>) async throws(WendyNetError) -> R
+    ) async throws(WendyNetError) -> R {
         let context = self.context
         let pipelineFactory = self.pipelineFactory
         let framerFactory = self.framerFactory
@@ -428,6 +884,72 @@ final class ListenerCore<Message: Sendable>: Sendable {
         case .failure(let e): throw e
         }
     }
+
+    private func executeThenCloseUDP<R: Sendable>(
+        _ datagramChannel: NIODatagramChannel,
+        _ body: @Sendable (Accepted<Message>) async throws(WendyNetError) -> R
+    ) async throws(WendyNetError) -> R {
+        let context = self.context
+        let pipelineFactory = self.pipelineFactory
+        let timeout = self.udpAssociationTimeout
+        // Framers are not applied: datagrams already carry message boundaries.
+
+        let outcome: Result<R, WendyNetError>
+        do {
+            outcome = try await datagramChannel.executeThenClose { inbound, outbound -> Result<R, WendyNetError> in
+                // Each accepted association idle-times-out within its own
+                // executeThenClose scope (see ChannelCore), so the hub only
+                // demultiplexes — no central reaper.
+                let hub = UDPDemuxHub<Message>(
+                    context: context,
+                    idleTimeout: timeout,
+                    pipelineFactory: pipelineFactory,
+                    writer: outbound
+                )
+                // The demux pump runs as a structured child of this scope; the
+                // accept iterator hands out per-peer channels spawned by the hub.
+                return await withTaskGroup(of: Void.self, returning: Result<R, WendyNetError>.self) { group in
+                    group.addTask { [hub] in
+                        do {
+                            for try await envelope in inbound {
+                                hub.deliver(envelope)
+                            }
+                            hub.finish(nil)
+                        } catch is CancellationError {
+                            hub.finish(nil)
+                        } catch {
+                            hub.finish(.listenerError)
+                        }
+                    }
+
+                    let accepted = Accepted<Message>(nextStep: { [hub] in
+                        await hub.nextAccepted()
+                    })
+
+                    let result: Result<R, WendyNetError>
+                    do throws(WendyNetError) {
+                        result = .success(try await body(accepted))
+                    } catch {
+                        result = .failure(error)
+                    }
+                    // First finish wins: if the pump already finished (socket
+                    // error), this is a no-op; otherwise it ends every live
+                    // association before the pump is torn down.
+                    hub.finish(nil)
+                    group.cancelAll()
+                    return result
+                }
+            }
+        } catch is CancellationError {
+            throw .cancelled
+        } catch {
+            throw .listenerError
+        }
+        switch outcome {
+        case .success(let v): return v
+        case .failure(let e): throw e
+        }
+    }
 }
 
 // MARK: - Bootstrap entry points
@@ -435,7 +957,6 @@ final class ListenerCore<Message: Sendable>: Sendable {
 extension ClientBootstrap {
     public func connect(to endpoint: Endpoint) async throws(WendyNetError) -> Channel<Message> {
         let _ = security
-        let _ = udpAssociationTimeoutSeconds
 
         let hostname: String
         let port: UInt16
@@ -447,9 +968,12 @@ extension ClientBootstrap {
             throw .connectionFailed
         }
 
-        let transport = TransportInfo(kind: .tcp, isStream: true)
+        let isStream = reliability == .reliable
+        let transport = TransportInfo(kind: isStream ? .tcp : .udp, isStream: isStream)
         var closures = pipelineFactory()
-        if let framerFactory = framerFactory {
+        // Framers are only meaningful on stream transports; datagrams already
+        // carry message boundaries.
+        if let framerFactory = framerFactory, isStream {
             closures = framerFactory().composing(closures)
         }
 
@@ -458,12 +982,26 @@ extension ClientBootstrap {
 
         let nioAsyncChannel: NIOByteBufferChannel
         do {
-            nioAsyncChannel = try await NIOPosix.ClientBootstrap(group: standardEventLoopGroup)
-                .connect(host: hostname, port: Int(port)) { channel in
-                    channel.eventLoop.makeCompletedFuture {
-                        try NIOByteBufferChannel(wrappingChannelSynchronously: channel)
+            if isStream {
+                nioAsyncChannel = try await NIOPosix.ClientBootstrap(group: standardEventLoopGroup)
+                    .connect(host: hostname, port: Int(port)) { channel in
+                        channel.eventLoop.makeCompletedFuture {
+                            try NIOByteBufferChannel(wrappingChannelSynchronously: channel)
+                        }
                     }
-                }
+            } else {
+                // Connected UDP: the kernel filters inbound traffic to this
+                // peer. The unwrap handler strips the AddressedEnvelope reads
+                // so the async channel deals in plain ByteBuffers; writes are
+                // plain ByteBuffers because connect() fixed the remote.
+                nioAsyncChannel = try await NIOPosix.DatagramBootstrap(group: standardEventLoopGroup)
+                    .connect(host: hostname, port: Int(port)) { channel in
+                        channel.eventLoop.makeCompletedFuture {
+                            try channel.pipeline.syncOperations.addHandler(DatagramUnwrapHandler())
+                            return try NIOByteBufferChannel(wrappingChannelSynchronously: channel)
+                        }
+                    }
+            }
         } catch is CancellationError {
             throw .cancelled
         } catch {
@@ -490,38 +1028,58 @@ extension ClientBootstrap {
 extension ServerBootstrap {
     public func bind(port: UInt16) async throws(WendyNetError) -> Listener<Message> {
         let _ = wendyNet
-        let _ = udpAssociationTimeoutSeconds
 
-        let transport = TransportInfo(kind: .tcp, isStream: true)
+        let isStream = reliability == .reliable
+        let transport = TransportInfo(kind: isStream ? .tcp : .udp, isStream: isStream)
         let endpoint = Endpoint.ipHost(hostname: "0.0.0.0", port: port)
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
 
         let pipelineFactory = self.pipelineFactory
         let framerFactory = self.framerFactory
 
-        let serverChannel: NIOServerInboundChannel
+        let backing: ListenerBacking
         do {
-            serverChannel = try await NIOPosix.ServerBootstrap(group: standardEventLoopGroup)
-                .serverChannelOption(ChannelOptions.backlog, value: 4)
-                .bind(host: "0.0.0.0", port: Int(port)) { childChannel in
-                    childChannel.eventLoop.makeCompletedFuture {
-                        try NIOByteBufferChannel(wrappingChannelSynchronously: childChannel)
+            if isStream {
+                let serverChannel: NIOServerInboundChannel = try await NIOPosix.ServerBootstrap(group: standardEventLoopGroup)
+                    .serverChannelOption(ChannelOptions.backlog, value: 4)
+                    .bind(host: "0.0.0.0", port: Int(port)) { childChannel in
+                        childChannel.eventLoop.makeCompletedFuture {
+                            try NIOByteBufferChannel(wrappingChannelSynchronously: childChannel)
+                        }
                     }
-                }
+                backing = .tcp(serverChannel)
+            } else {
+                // Unconnected UDP: one bound datagram channel for the whole
+                // listener; per-peer associations are demultiplexed by source
+                // address inside ListenerCore's executeThenClose.
+                let datagramChannel: NIODatagramChannel = try await NIOPosix.DatagramBootstrap(group: standardEventLoopGroup)
+                    .bind(host: "0.0.0.0", port: Int(port)) { channel in
+                        channel.eventLoop.makeCompletedFuture {
+                            try NIODatagramChannel(wrappingChannelSynchronously: channel)
+                        }
+                    }
+                backing = .udp(datagramChannel)
+            }
         } catch is CancellationError {
             throw .cancelled
         } catch {
             throw .listenerError
         }
 
-        guard let resolvedPort = serverChannel.channel.localAddress?.port.map(UInt16.init) else {
+        let boundChannel: NIOCore.Channel
+        switch backing {
+        case .tcp(let serverChannel): boundChannel = serverChannel.channel
+        case .udp(let datagramChannel): boundChannel = datagramChannel.channel
+        }
+        guard let resolvedPort = boundChannel.localAddress?.port.map(UInt16.init) else {
             throw .listenerError
         }
 
         let core = ListenerCore<Message>(
             port: resolvedPort,
             context: context,
-            serverChannel: serverChannel,
+            backing: backing,
+            udpAssociationTimeout: udpAssociationTimeout,
             pipelineFactory: pipelineFactory,
             framerFactory: framerFactory
         )

--- a/Sources/WendyNet/Backend+WendyLite.swift
+++ b/Sources/WendyNet/Backend+WendyLite.swift
@@ -70,6 +70,9 @@ fileprivate final class LockedBox<T>: @unchecked Sendable {
     }
 }
 
+/// Guest-side UDP receive buffer. Must be >= the host's CONFIG_WENDY_NET_BUFFER_SIZE.
+private let wendyNetDatagramBufferSize = 1500
+
 // MARK: - Parked-waiter helper
 //
 // The single-parked-continuation pattern shared by the listener's accept loop
@@ -135,15 +138,35 @@ private enum WendyNetNative {
         wendynet_tcp_listen(Int32(port), backlog)
     }
 
-    static func connect(hostname: String, port: UInt16) -> Int32 {
+    /// Marshal a hostname into the `(const char *, int32 len)` pair the host
+    /// imports expect. Returns -1 for an empty string (no base address).
+    private static func withHostname(
+        _ hostname: String,
+        _ body: (UnsafePointer<CChar>, Int32) -> Int32
+    ) -> Int32 {
         let bytes = Array(hostname.utf8)
         return bytes.withUnsafeBufferPointer { ptr in
             guard let baseAddress = ptr.baseAddress else { return -1 }
-            return wendynet_tcp_connect(
+            return body(
                 UnsafeRawPointer(baseAddress).assumingMemoryBound(to: CChar.self),
-                Int32(ptr.count),
-                Int32(port)
+                Int32(ptr.count)
             )
+        }
+    }
+
+    static func connect(hostname: String, port: UInt16) -> Int32 {
+        withHostname(hostname) { ptr, len in
+            wendynet_tcp_connect(ptr, len, Int32(port))
+        }
+    }
+
+    static func udpListen(port: UInt16) -> Int32 {
+        wendynet_udp_listen(Int32(port))
+    }
+
+    static func udpConnect(hostname: String, port: UInt16) -> Int32 {
+        withHostname(hostname) { ptr, len in
+            wendynet_udp_connect(ptr, len, Int32(port))
         }
     }
 
@@ -296,6 +319,9 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
     let handle: Int32
     let port: UInt16
     let context: ConnectionContext
+    /// Idle timeout applied to each accepted UDP association (`.zero` for TCP,
+    /// which disables it).
+    let udpAssociationTimeout: Duration
     private struct State {
         var pendingChannels: [Channel<Message>] = []
         var acceptWaiter: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>? = nil
@@ -306,10 +332,17 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
     }
     private let state: LockedBox<State>
 
-    init(handle: Int32, port: UInt16, context: ConnectionContext, closures: PipelineClosures<Message>) {
+    init(
+        handle: Int32,
+        port: UInt16,
+        context: ConnectionContext,
+        udpAssociationTimeout: Duration,
+        closures: PipelineClosures<Message>
+    ) {
         self.handle = handle
         self.port = port
         self.context = context
+        self.udpAssociationTimeout = udpAssociationTimeout
         self.state = LockedBox(State(closures: closures))
     }
 
@@ -406,6 +439,7 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
                             handle: socketHandle,
                             endpoint: context.remoteEndpoint,
                             transport: context.transport,
+                            idleTimeout: udpAssociationTimeout,
                             decode: s.closures.decode,
                             encode: s.closures.encode
                         )
@@ -475,6 +509,9 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
     let handle: Int32
     let endpoint: Endpoint
     let transport: TransportInfo
+    /// Idle timeout for a UDP-listener association (`.zero` for TCP / clients,
+    /// which disables it).
+    let idleTimeout: Duration
     private struct State {
         var decode: (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void
         var encode: (Message) -> ByteBuffer
@@ -483,6 +520,8 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         var writableWaiter: CheckedContinuation<Void, Never>? = nil
         var closed = false
         var error: WendyNetError? = nil
+        /// Last inbound/outbound activity, for idle reaping.
+        var lastActivity: WendyClock.Instant
         /// Single-use latch -- see `executeThenClose` for rationale.
         var executeThenCloseUsed = false
     }
@@ -492,13 +531,25 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
         handle: Int32,
         endpoint: Endpoint,
         transport: TransportInfo,
+        idleTimeout: Duration = .zero,
         decode: @escaping (ByteBuffer, (Message) -> Void, (WendyNetError) -> Void) -> Void,
         encode: @escaping (Message) -> ByteBuffer
     ) {
         self.handle = handle
         self.endpoint = endpoint
         self.transport = transport
-        self.state = LockedBox(State(decode: decode, encode: encode))
+        self.idleTimeout = idleTimeout
+        self.state = LockedBox(State(decode: decode, encode: encode, lastActivity: WendyClock().now))
+    }
+
+    /// Time left before the idle deadline (`idleTimeout` since the last
+    /// activity): `nil` once closed/errored, `<= .zero` once expired.
+    private func idleRemaining() -> Duration? {
+        state.withLockedValue { s in
+            (s.closed || s.error != nil)
+                ? nil
+                : idleTimeout - s.lastActivity.duration(to: WendyClock().now)
+        }
     }
 
     private func receive() async throws(WendyNetError) -> Message? {
@@ -606,6 +657,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 let resolved: WendyNetError = state.withLockedValue { s in s.error ?? .closed }
                 return .failure(resolved)
             }
+            state.withLockedValue { s in s.lastActivity = WendyClock().now }
             return .success(())
         }, onCancel: { [self] in
             let shouldClose: Bool = state.withLockedValue { s in !s.closed && s.error == nil }
@@ -653,14 +705,32 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 return .failure(error)
             }
         })
-        let outcome: Result<R, WendyNetError>
-        do throws(WendyNetError) {
-            let value = try await body(inbound, outbound)
-            outcome = .success(value)
-        } catch {
-            outcome = .failure(error)
-        }
-        await close()
+
+        // Run the body alongside the association's idle timer; cancelling the
+        // group when the body returns tears the timer down with the channel.
+        // If the timer fires first it closes the channel, surfacing
+        // end-of-stream to the body.
+        let outcome: Result<R, WendyNetError> =
+            await withTaskGroup(of: Void.self, returning: Result<R, WendyNetError>.self) { group in
+                if idleTimeout > .zero {
+                    group.addTask { [self] in
+                        await runIdleTimer(
+                            remaining: { [self] in idleRemaining() },
+                            sleep: { d in (try? await WendyClock().sleep(for: d)) != nil },
+                            evict: { [self] in await close() }
+                        )
+                    }
+                }
+                let result: Result<R, WendyNetError>
+                do throws(WendyNetError) {
+                    result = .success(try await body(inbound, outbound))
+                } catch {
+                    result = .failure(error)
+                }
+                await close()
+                group.cancelAll()
+                return result
+            }
         switch outcome {
         case .success(let v): return v
         case .failure(let e): throw e
@@ -670,7 +740,8 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
     func drainReadable() {
         let alreadyDone: Bool = state.withLockedValue { s in s.closed || s.error != nil }
         if alreadyDone { return }
-        var buffer = [UInt8](repeating: 0, count: 256)
+        // Sized to hold one whole UDP datagram (see wendyNetDatagramBufferSize).
+        var buffer = [UInt8](repeating: 0, count: wendyNetDatagramBufferSize)
 
         while true {
             let read = WendyNetNative.recv(socketHandle: handle, into: &buffer)
@@ -678,6 +749,7 @@ final class ChannelCore<Message: Sendable>: AnyChannelCore, Sendable {
                 let input = ByteBuffer(bytes: Array(buffer[0 ..< Int(read)]))
                 let waiterToResume: (CheckedContinuation<Result<Message?, WendyNetError>, Never>, Result<Message?, WendyNetError>)? =
                     state.withLockedValue { s -> (CheckedContinuation<Result<Message?, WendyNetError>, Never>, Result<Message?, WendyNetError>)? in
+                        s.lastActivity = WendyClock().now
                         s.decode(input, { message in
                             s.decodedMessages.append(message)
                         }, { failure in
@@ -873,7 +945,6 @@ extension ClientBootstrap {
     /// Connect to an endpoint. TAPS-style transport racing happens internally.
     public func connect(to endpoint: Endpoint) async throws(WendyNetError) -> Channel<Message> {
         let _ = security
-        let _ = udpAssociationTimeoutSeconds
         guard WendyNetState.shared.ensureInitialized() else {
             throw .connectionFailed
         }
@@ -888,14 +959,22 @@ extension ClientBootstrap {
             throw .connectionFailed
         }
 
-        let handle = WendyNetNative.connect(hostname: hostname, port: port)
+        let isStream = reliability == .reliable
+        let handle: Int32
+        if isStream {
+            handle = WendyNetNative.connect(hostname: hostname, port: port)
+        } else {
+            handle = WendyNetNative.udpConnect(hostname: hostname, port: port)
+        }
         if handle <= 0 {
             throw .connectionFailed
         }
 
-        let transport = TransportInfo(kind: .tcp, isStream: true)
+        let transport = TransportInfo(kind: isStream ? .tcp : .udp, isStream: isStream)
         var closures = pipelineFactory()
-        if let framerFactory = framerFactory {
+        // Framers are only meaningful on stream transports; datagrams already
+        // carry message boundaries.
+        if let framerFactory = framerFactory, isStream {
             closures = framerFactory().composing(closures)
         }
 
@@ -932,22 +1011,29 @@ extension ServerBootstrap {
     /// Bind to a port.
     public func bind(port: UInt16) async throws(WendyNetError) -> Listener<Message> {
         let _ = wendyNet
-        let _ = udpAssociationTimeoutSeconds
         guard WendyNetState.shared.ensureInitialized() else {
             throw .listenerError
         }
 
-        let transport = TransportInfo(kind: .tcp, isStream: true)
+        let isStream = reliability == .reliable
+        let transport = TransportInfo(kind: isStream ? .tcp : .udp, isStream: isStream)
         let endpoint = Endpoint.ipHost(hostname: "0.0.0.0", port: port)
         var closures = pipelineFactory()
-        if let framerFactory = framerFactory {
+        // Framers are only meaningful on stream transports; datagrams already
+        // carry message boundaries.
+        if let framerFactory = framerFactory, isStream {
             closures = framerFactory().composing(closures)
         }
 
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
         closures.started(context)
 
-        let handle = WendyNetNative.listen(port: port, backlog: 4)
+        let handle: Int32
+        if isStream {
+            handle = WendyNetNative.listen(port: port, backlog: 4)
+        } else {
+            handle = WendyNetNative.udpListen(port: port)
+        }
         if handle <= 0 {
             throw .listenerError
         }
@@ -962,7 +1048,13 @@ extension ServerBootstrap {
         }
         let resolvedPort = UInt16(resolvedRaw)
 
-        let core = ListenerCore<Message>(handle: handle, port: resolvedPort, context: context, closures: closures)
+        let core = ListenerCore<Message>(
+            handle: handle,
+            port: resolvedPort,
+            context: context,
+            udpAssociationTimeout: isStream ? .zero : udpAssociationTimeout,
+            closures: closures
+        )
         WendyNetState.shared.register(listener: core)
         return Listener(port: resolvedPort, core: core)
     }

--- a/Sources/WendyNet/Backend+WendyLite.swift
+++ b/Sources/WendyNet/Backend+WendyLite.swift
@@ -322,11 +322,15 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
     /// Idle timeout applied to each accepted UDP association (`.zero` for TCP,
     /// which disables it).
     let udpAssociationTimeout: Duration
+    // A fresh pipeline is built per accepted connection so peers never share
+    // stage state.
+    private let pipelineFactory: @Sendable () -> PipelineClosures<Message>
+    private let framerFactory: (@Sendable () -> FramerClosures)?
+    private let isStream: Bool
     private struct State {
         var pendingChannels: [Channel<Message>] = []
         var acceptWaiter: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>? = nil
         var isClosed = false
-        var closures: PipelineClosures<Message>
         /// Single-use latch -- see `executeThenClose` for rationale.
         var executeThenCloseUsed = false
     }
@@ -337,13 +341,18 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
         port: UInt16,
         context: ConnectionContext,
         udpAssociationTimeout: Duration,
-        closures: PipelineClosures<Message>
+        isStream: Bool,
+        pipelineFactory: @escaping @Sendable () -> PipelineClosures<Message>,
+        framerFactory: (@Sendable () -> FramerClosures)?
     ) {
         self.handle = handle
         self.port = port
         self.context = context
         self.udpAssociationTimeout = udpAssociationTimeout
-        self.state = LockedBox(State(closures: closures))
+        self.isStream = isStream
+        self.pipelineFactory = pipelineFactory
+        self.framerFactory = framerFactory
+        self.state = LockedBox(State())
     }
 
     private func accept() async throws(WendyNetError) -> Channel<Message>? {
@@ -431,37 +440,41 @@ final class ListenerCore<Message: Sendable>: AnyListenerCore, Sendable {
         while true {
             let socketHandle = WendyNetNative.accept(listenerHandle: handle)
             if socketHandle > 0 {
-                // Build a fresh channel core under our lock so the per-connection
-                // closures are constructed once and stay confined to that core.
-                let (channelCore, channel): (ChannelCore<Message>, Channel<Message>) =
-                    state.withLockedValue { s in
-                        let core = ChannelCore<Message>(
-                            handle: socketHandle,
-                            endpoint: context.remoteEndpoint,
-                            transport: context.transport,
-                            idleTimeout: udpAssociationTimeout,
-                            decode: s.closures.decode,
-                            encode: s.closures.encode
-                        )
-                        let channel = Channel<Message>(
-                            endpoint: context.remoteEndpoint,
-                            transport: context.transport,
-                            maximumMessageLength: wendyNetMaximumMessageLength,
-                            core: core
-                        )
-                        return (core, channel)
-                    }
-                WendyNetState.shared.register(channel: channelCore)
+                var closures = pipelineFactory()
+                if let framerFactory, isStream {
+                    closures = framerFactory().composing(closures)
+                }
+                let core = ChannelCore<Message>(
+                    handle: socketHandle,
+                    endpoint: context.remoteEndpoint,
+                    transport: context.transport,
+                    idleTimeout: udpAssociationTimeout,
+                    decode: closures.decode,
+                    encode: closures.encode
+                )
+                let channel = Channel<Message>(
+                    endpoint: context.remoteEndpoint,
+                    transport: context.transport,
+                    maximumMessageLength: wendyNetMaximumMessageLength,
+                    core: core
+                )
 
-                let resume: CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>? =
+                let (resume, dropped): (CheckedContinuation<Result<Channel<Message>?, WendyNetError>, Never>?, Bool) =
                     state.withLockedValue { s in
+                        if s.isClosed { return (nil, true) }
                         if let waiter = s.acceptWaiter {
                             s.acceptWaiter = nil
-                            return waiter
+                            return (waiter, false)
                         }
                         s.pendingChannels.append(channel)
-                        return nil
+                        return (nil, false)
                     }
+                if dropped {
+                    WendyNetNative.closeSocket(socketHandle)
+                    continue
+                }
+                closures.started(context)
+                WendyNetState.shared.register(channel: core)
                 resume?.resume(returning: .success(channel))
                 continue
             }
@@ -979,7 +992,6 @@ extension ClientBootstrap {
         }
 
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
-        closures.started(context)
 
         let core = ChannelCore<Message>(
             handle: handle,
@@ -997,6 +1009,8 @@ extension ClientBootstrap {
             WendyNetNative.closeSocket(handle)
             throw error
         }
+
+        closures.started(context)
 
         return Channel(
             endpoint: endpoint,
@@ -1018,15 +1032,7 @@ extension ServerBootstrap {
         let isStream = reliability == .reliable
         let transport = TransportInfo(kind: isStream ? .tcp : .udp, isStream: isStream)
         let endpoint = Endpoint.ipHost(hostname: "0.0.0.0", port: port)
-        var closures = pipelineFactory()
-        // Framers are only meaningful on stream transports; datagrams already
-        // carry message boundaries.
-        if let framerFactory = framerFactory, isStream {
-            closures = framerFactory().composing(closures)
-        }
-
         let context = ConnectionContext(remoteEndpoint: endpoint, transport: transport, security: security)
-        closures.started(context)
 
         let handle: Int32
         if isStream {
@@ -1053,7 +1059,9 @@ extension ServerBootstrap {
             port: resolvedPort,
             context: context,
             udpAssociationTimeout: isStream ? .zero : udpAssociationTimeout,
-            closures: closures
+            isStream: isStream,
+            pipelineFactory: pipelineFactory,
+            framerFactory: framerFactory
         )
         WendyNetState.shared.register(listener: core)
         return Listener(port: resolvedPort, core: core)

--- a/Sources/WendyNet/Internal.swift
+++ b/Sources/WendyNet/Internal.swift
@@ -22,6 +22,30 @@ enum AcceptedStep<Message: Sendable>: Sendable {
     case failure(WendyNetError)
 }
 
+// MARK: - Idle timer
+
+/// Backend-agnostic idle-timeout loop for a UDP association, run as a child of
+/// the channel's `executeThenClose` scope so it is cancelled when the channel
+/// is done. `remaining` reports the time left until the deadline (`timeout`
+/// since last activity), `nil` once the association has ended, or `<= .zero`
+/// once it has expired; `sleep` waits for a `Duration`, returning `false` if
+/// cancelled; `evict` reclaims the idle association. Re-reading `remaining`
+/// after each sleep reschedules precisely against the latest activity.
+func runIdleTimer(
+    remaining: @Sendable () -> Duration?,
+    sleep: @Sendable (Duration) async -> Bool,
+    evict: @Sendable () async -> Void
+) async {
+    while true {
+        guard let left = remaining() else { return }
+        if left <= .zero {
+            await evict()
+            return
+        }
+        if await sleep(left) == false { return }  // cancelled
+    }
+}
+
 // MARK: - Pipeline closures
 
 /// Closure bundle produced by a pipeline factory.
@@ -65,7 +89,7 @@ struct FramerClosures {
 /// Shared configuration backing both `ClientBootstrap` and `ServerBootstrap`.
 struct BootstrapConfig<Message: Sendable>: Sendable {
     var security: SecurityMode = .insecure
-    var udpAssociationTimeoutSeconds: Int = 60
+    var reliability: Reliability = .reliable
     let pipelineFactory: @Sendable () -> PipelineClosures<Message>
     var framerFactory: (@Sendable () -> FramerClosures)? = nil
 
@@ -90,7 +114,7 @@ struct BootstrapConfig<Message: Sendable>: Sendable {
     ) -> BootstrapConfig<New> {
         BootstrapConfig<New>(
             security: security,
-            udpAssociationTimeoutSeconds: udpAssociationTimeoutSeconds,
+            reliability: reliability,
             pipelineFactory: pipelineFactory,
             framerFactory: framerFactory
         )

--- a/Tests/WendyNetTests/UDPTests.swift
+++ b/Tests/WendyNetTests/UDPTests.swift
@@ -123,4 +123,52 @@ func udpServerSeesMultiplePeersAsDistinctChannels() async throws {
 
     #expect(seen.value.sorted() == ["from-a", "from-b"])
 }
+
+/// Passthrough stage that records the identity of each instance whose `started`
+/// hook fires, so a test can prove peers don't share a pipeline.
+private final class CountingStage: PipelineStage, @unchecked Sendable {
+    typealias Input = ByteBuffer
+    typealias Output = ByteBuffer
+    let startedIDs: TestBox<[ObjectIdentifier]>
+    init(startedIDs: TestBox<[ObjectIdentifier]>) { self.startedIDs = startedIDs }
+    func started(context: ConnectionContext) {
+        startedIDs.value.append(ObjectIdentifier(self))
+    }
+    func decode(_ input: ByteBuffer, _ emit: (ByteBuffer) -> Void, _ fail: (WendyNetError) -> Void) {
+        emit(input)
+    }
+    func encode(_ output: ByteBuffer) -> ByteBuffer { output }
+}   
+
+@Test
+func udpServerBuildsIndependentPipelinePerPeer() async throws {
+    let net = WendyNet()
+    let startedIDs = TestBox<[ObjectIdentifier]>([])
+
+    let listener = try await ServerBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .pipeline { CountingStage(startedIDs: startedIDs) }
+        .bind(port: 0)
+
+    let seen = TestBox<[String]>([])
+    let serverTask = Task {
+        try? await acceptTwoAndCollect(listener: listener, seen: seen)
+    }
+
+    let clientA = try await ClientBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .connect(to: Endpoint(hostname: "127.0.0.1", port: listener.port))
+    let clientB = try await ClientBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .connect(to: Endpoint(hostname: "127.0.0.1", port: listener.port))
+
+    try await sendOne(client: clientA, text: "from-a")
+    try await sendOne(client: clientB, text: "from-b")
+
+    _ = await serverTask.value
+
+    #expect(seen.value.sorted() == ["from-a", "from-b"])
+    #expect(startedIDs.value.count == 2, "each peer should get its own started() call")
+    #expect(Set(startedIDs.value).count == 2, "peers must not share a pipeline stage instance")
+}
 #endif

--- a/Tests/WendyNetTests/UDPTests.swift
+++ b/Tests/WendyNetTests/UDPTests.swift
@@ -1,0 +1,126 @@
+#if WendyNetBackendStandard
+import Testing
+@testable import WendyNet
+
+/// Test-only holder for mutable state captured into @Sendable closures.
+private final class TestBox<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
+}
+
+// MARK: - Named helpers
+//
+// Swift 6.3.1 has a SIL crash (LifetimeDependenceDiagnostics) when generating
+// thunks for nested typed-throws closures captured into Task initialisers.
+// Extracting the closure bodies into named async functions sidesteps the bug.
+
+private func runUDPEchoServer(listener: Listener<ByteBuffer>, captured: TestBox<[UInt8]>) async throws(WendyNetError) {
+    try await listener.executeThenClose { accepted throws(WendyNetError) in
+        guard let serverChannel = try await accepted.next() else { return }
+        try await echoOnce(channel: serverChannel, captured: captured)
+    }
+}
+
+private func echoOnce(channel: Channel<ByteBuffer>, captured: TestBox<[UInt8]>) async throws(WendyNetError) {
+    try await channel.executeThenClose { inbound, outbound throws(WendyNetError) in
+        guard var msg = try await inbound.next() else { return }
+        let bytes = msg.readBytes(length: msg.readableBytes) ?? []
+        captured.value = bytes
+        _ = try await outbound.write(ByteBuffer(bytes: bytes))
+    }
+}
+
+private func sendAndReceive(client: Channel<ByteBuffer>, payload: [UInt8], response: TestBox<[UInt8]>) async throws(WendyNetError) {
+    try await client.executeThenClose { inbound, outbound throws(WendyNetError) in
+        _ = try await outbound.write(ByteBuffer(bytes: payload))
+        if var reply = try await inbound.next() {
+            response.value = reply.readBytes(length: reply.readableBytes) ?? []
+        }
+    }
+}
+
+private func acceptTwoAndCollect(listener: Listener<ByteBuffer>, seen: TestBox<[String]>) async throws(WendyNetError) {
+    try await listener.executeThenClose { accepted throws(WendyNetError) in
+        for _ in 0 ..< 2 {
+            guard let channel = try await accepted.next() else { break }
+            try await collectOne(channel: channel, seen: seen)
+        }
+    }
+}
+
+private func collectOne(channel: Channel<ByteBuffer>, seen: TestBox<[String]>) async throws(WendyNetError) {
+    try await channel.executeThenClose { inbound, _ throws(WendyNetError) in
+        guard var msg = try await inbound.next() else { return }
+        let bytes = msg.readBytes(length: msg.readableBytes) ?? []
+        seen.value.append(String(decoding: bytes, as: UTF8.self))
+    }
+}
+
+private func sendOne(client: Channel<ByteBuffer>, text: String) async throws(WendyNetError) {
+    try await client.executeThenClose { _, outbound throws(WendyNetError) in
+        _ = try await outbound.write(ByteBuffer(bytes: Array(text.utf8)))
+    }
+}
+
+// MARK: - Tests
+
+@Test
+func udpRoundTrip() async throws {
+    let net = WendyNet()
+
+    let listener = try await ServerBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .security(.insecure)
+        .bind(port: 0)
+
+    let serverCaptured = TestBox<[UInt8]>([])
+    let serverTask = Task {
+        try? await runUDPEchoServer(listener: listener, captured: serverCaptured)
+    }
+
+    let client = try await ClientBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .security(.insecure)
+        .connect(to: Endpoint(hostname: "127.0.0.1", port: listener.port))
+
+    #expect(client.transport.kind == .udp)
+    #expect(client.transport.isDatagramOriented)
+
+    let payload: [UInt8] = Array("ping".utf8)
+    let responseBox = TestBox<[UInt8]>([])
+    try await sendAndReceive(client: client, payload: payload, response: responseBox)
+
+    _ = await serverTask.value
+
+    #expect(serverCaptured.value == payload, "server received bytes did not match what client sent")
+    #expect(responseBox.value == payload, "client did not receive the echoed payload")
+}
+
+@Test
+func udpServerSeesMultiplePeersAsDistinctChannels() async throws {
+    let net = WendyNet()
+
+    let listener = try await ServerBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .bind(port: 0)
+
+    let seen = TestBox<[String]>([])
+    let serverTask = Task {
+        try? await acceptTwoAndCollect(listener: listener, seen: seen)
+    }
+
+    let clientA = try await ClientBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .connect(to: Endpoint(hostname: "127.0.0.1", port: listener.port))
+    let clientB = try await ClientBootstrap(wendyNet: net)
+        .reliability(.unreliable)
+        .connect(to: Endpoint(hostname: "127.0.0.1", port: listener.port))
+
+    try await sendOne(client: clientA, text: "from-a")
+    try await sendOne(client: clientB, text: "from-b")
+
+    _ = await serverTask.value
+
+    #expect(seen.value.sorted() == ["from-a", "from-b"])
+}
+#endif


### PR DESCRIPTION
Add an unreliable/datagram transport alongside TCP, selected via `.reliability(.unreliable)`:

- Client: a connected UDP socket. This is one fixed peer, so the kernel filters inbound and surfaces ICMP errors.
- Server: an unconnected bound socket whose datagrams are demultiplexed by source address into per-peer associations, each surfaced as an accepted Channel
- Per-association idle timeout `udpAssociationTimeout` implemented as a structured per-channel timer in the frontend, driven by `ContinuousClock`/`WendyClock`

This relies on new WASM imports that will be added in a related `wendy-lite` PR (https://github.com/wendylabsinc/wendy-lite/pull/12). Tests for `Standard` are included. The `wendy-lite` PR includes a new Swift guest application where ESP32 devices send and receive messages from each other successfully using this new API.

Today we have a simple relationship between reliability and protocol: reliable is TCP, unreliable is UDP. In the near future we will add support for Bluetooth L2CAP, which is always reliable, even if the user said that unreliable is insufficient. (The developer will need to supply or at least specify a framer.)